### PR TITLE
RS-55: Add `--only-entrie`s option to delete only entries in `bucket rm` cmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+### Added:
+
+- RS-55: `--only-entries` option to delete only entries in `bucket rm` cmd, [PR-8](https://github.com/reductstore/reduct-cli/pull/8)
+
 ### Fixed:
 
 - Wrong file extension for application/octet-stream content type in `reduct-cli cp` command, [PR-4](https://github.com/reductstore/reduct-cli/pull/4)

--- a/src/cmd/bucket/rm.rs
+++ b/src/cmd/bucket/rm.rs
@@ -7,7 +7,7 @@ use crate::context::CliContext;
 use crate::cmd::RESOURCE_PATH_HELP;
 use crate::io::reduct::build_client;
 use crate::io::std::output;
-use crate::parse::ResourcePathParser;
+use crate::parse::{fetch_and_filter_entries, ResourcePathParser};
 use clap::ArgAction::SetTrue;
 use clap::{Arg, ArgMatches, Command};
 use reduct_rs::ReductClient;
@@ -22,6 +22,15 @@ pub(super) fn rm_bucket_cmd() -> Command {
                 .required(true),
         )
         .arg(
+            Arg::new("only-entries")
+                .long("only-entries")
+                .short('e')
+                .value_name("ENTRY_NAME")
+                .help("Remove only the specified entry instead of the whole bucket")
+                .num_args(1..)
+                .required(false),
+        )
+        .arg(
             Arg::new("yes")
                 .long("yes")
                 .short('y')
@@ -33,8 +42,28 @@ pub(super) fn rm_bucket_cmd() -> Command {
 
 pub(super) async fn rm_bucket(ctx: &CliContext, args: &ArgMatches) -> anyhow::Result<()> {
     let (alias_or_url, bucket_name) = args.get_one::<(String, String)>("BUCKET_PATH").unwrap();
+    let only_entries = args
+        .get_many::<String>("only-entries")
+        .unwrap_or_default()
+        .map(|s| s.to_string())
+        .collect::<Vec<String>>();
 
-    let confirm = if !args.get_flag("yes") {
+    if !only_entries.is_empty() {
+        remove_entries(ctx, args, alias_or_url, bucket_name, only_entries).await?;
+    } else {
+        remove_entire_bucket(ctx, args, alias_or_url, bucket_name).await?;
+    }
+    Ok(())
+}
+
+async fn remove_entire_bucket(
+    ctx: &CliContext,
+    args: &ArgMatches,
+    alias_or_url: &String,
+    bucket_name: &String,
+) -> anyhow::Result<()> {
+    let yes = args.get_flag("yes");
+    let confirm = if !yes {
         let confirm = dialoguer::Confirm::new()
             .default(false)
             .with_prompt(format!(
@@ -55,7 +84,52 @@ pub(super) async fn rm_bucket(ctx: &CliContext, args: &ArgMatches) -> anyhow::Re
     } else {
         output!(ctx, "Bucket '{}' not deleted", bucket_name);
     }
+    Ok(())
+}
 
+async fn remove_entries(
+    ctx: &CliContext,
+    args: &ArgMatches,
+    alias_or_url: &String,
+    bucket_name: &String,
+    only_entries: Vec<String>,
+) -> anyhow::Result<()> {
+    let client: ReductClient = build_client(ctx, alias_or_url).await?;
+    let bucket = client.get_bucket(bucket_name).await?;
+
+    let entries = fetch_and_filter_entries(&bucket, &only_entries)
+        .await?
+        .iter()
+        .map(|entry| entry.name.clone())
+        .collect::<Vec<String>>();
+    if entries.is_empty() {
+        output!(ctx, "No entries found to delete");
+        return Ok(());
+    }
+
+    let yes = args.get_flag("yes");
+    let confirm = if !yes {
+        let confirm = dialoguer::Confirm::new()
+            .default(false)
+            .with_prompt(format!(
+                "Are you sure you want to delete {:?} entries from bucket '{}'?",
+                entries, bucket_name,
+            ))
+            .interact()?;
+        confirm
+    } else {
+        true
+    };
+
+    if confirm {
+        for entry in &entries {
+            bucket.remove_entry(entry).await?;
+        }
+
+        output!(ctx, "Entries {:?} deleted", entries);
+    } else {
+        output!(ctx, "Entries {:?} not deleted", entries);
+    }
     Ok(())
 }
 
@@ -63,6 +137,7 @@ pub(super) async fn rm_bucket(ctx: &CliContext, args: &ArgMatches) -> anyhow::Re
 mod tests {
     use super::*;
     use crate::context::tests::{bucket, context};
+    use bytes::Bytes;
     use reduct_rs::ErrorCode;
     use rstest::*;
 
@@ -92,6 +167,46 @@ mod tests {
         assert_eq!(
             context.stdout().history(),
             vec!["Bucket 'test_bucket' deleted"]
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_rm_bucket_only_entries(context: CliContext, #[future] bucket: String) {
+        let bucket_name = bucket.await;
+        let client = build_client(&context, "local").await.unwrap();
+        let bucket = client.create_bucket(&bucket_name).send().await.unwrap();
+
+        bucket
+            .write_record("test")
+            .data(Bytes::from_static(b"test"))
+            .send()
+            .await
+            .unwrap();
+
+        let args = rm_bucket_cmd().get_matches_from(vec![
+            "rm",
+            format!("local/{}", bucket_name).as_str(),
+            "--yes",
+            "--only-entries",
+            "test",
+        ]);
+
+        assert_eq!(rm_bucket(&context, &args).await.unwrap(), ());
+        assert_eq!(
+            client
+                .get_bucket(&bucket_name)
+                .await
+                .unwrap()
+                .entries()
+                .await
+                .unwrap()
+                .len(),
+            0
+        );
+        assert_eq!(
+            context.stdout().history(),
+            vec!["Entries [\"test\"] deleted"]
         );
     }
 

--- a/src/cmd/bucket/rm.rs
+++ b/src/cmd/bucket/rm.rs
@@ -26,7 +26,7 @@ pub(super) fn rm_bucket_cmd() -> Command {
                 .long("only-entries")
                 .short('e')
                 .value_name("ENTRY_NAME")
-                .help("Remove only the specified entry instead of the whole bucket")
+                .help("Remove only the specified entry instead of the whole bucket. Wildcards are supported.")
                 .num_args(1..)
                 .required(false),
         )

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -4,10 +4,12 @@
 //    file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 mod byte_size;
+mod helpers;
 mod quota_type;
 mod resource_path;
 pub(crate) mod widely_used_args;
 
 pub(crate) use byte_size::ByteSizeParser;
+pub(crate) use helpers::fetch_and_filter_entries;
 pub(crate) use quota_type::QuotaTypeParser;
 pub(crate) use resource_path::ResourcePathParser;

--- a/src/parse/helpers.rs
+++ b/src/parse/helpers.rs
@@ -1,0 +1,29 @@
+// Copyright 2024 ReductStore
+// This Source Code Form is subject to the terms of the Mozilla Public
+//    License, v. 2.0. If a copy of the MPL was not distributed with this
+//    file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use reduct_rs::{Bucket, EntryInfo};
+
+pub(crate) async fn fetch_and_filter_entries(
+    src_bucket: &Bucket,
+    entry_filter: &Vec<String>,
+) -> anyhow::Result<Vec<EntryInfo>> {
+    let entries = src_bucket
+        .entries()
+        .await?
+        .iter()
+        .filter(|entry| -> bool {
+            if entry_filter.is_empty() || entry_filter.contains(&entry.name) {
+                true
+            } else {
+                // check wildcard
+                entry_filter.iter().any(|filter| {
+                    filter.ends_with('*') && entry.name.starts_with(&filter[..filter.len() - 1])
+                })
+            }
+        })
+        .map(|entry| entry.clone())
+        .collect::<Vec<EntryInfo>>();
+    Ok(entries)
+}


### PR DESCRIPTION
Closes #1 

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

I've added the `--only-entrie`s option to delete only entries in the `bucket rm` command:

```
reduct-cli  bucket rm play/stress_test --only-entries entry-*
```

### Related issues

#1 

### Does this PR introduce a breaking change?

No

### Other information:
