### PR TITLE
RS-333: Support `each-n` and `each-s` downsampling parameters  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added:
+
+- RS-318: Downsampling options for `reduct-cli cp` and `reduct-cli replica` commands, [PR-10](https://github.com/reductstore/reduct-cli/pull/10)
+
 ## [0.2.0] - 2024-04-29
 
 ### Added:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,15 +164,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.7"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -218,9 +212,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d04d43504c61aa6c7531f1871dd0d418d91130162063b789da00fd7057a5e"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -297,16 +291,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,15 +347,6 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "equivalent"
@@ -556,25 +531,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
-name = "h2"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -594,17 +550,6 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
@@ -616,12 +561,24 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
 dependencies = [
  "bytes",
- "http 0.2.12",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -632,47 +589,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
 name = "hyper"
-version = "0.14.28"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
 dependencies = [
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
- "h2",
- "http 0.2.12",
+ "http",
  "http-body",
  "httparse",
- "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "smallvec",
  "tokio",
- "tower-service",
- "tracing",
  "want",
 ]
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
- "http 0.2.12",
+ "http",
  "hyper",
+ "hyper-util",
  "rustls",
+ "rustls-pki-types",
  "tokio",
  "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -800,7 +770,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags",
  "libc",
 ]
 
@@ -955,6 +925,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "pin-project"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -971,6 +961,12 @@ name = "portable-atomic"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "predicates"
@@ -1042,12 +1038,89 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ceeeeabace7857413798eb1ffa1e9c905a9946a57d81fb69b4b71c4d8eb3ad"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddf517c03a109db8100448a4be38d498df8a210a99fe0e1b9eaf39e78c640efe"
+dependencies = [
+ "bytes",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9096629c45860fc7fb143e125eb826b5e721e10be3263160c7d60ca832cf8c46"
+dependencies = [
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -1063,12 +1136,12 @@ dependencies = [
 
 [[package]]
 name = "reduct-base"
-version = "1.9.4"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef7bce6118a32caea83f08d762d13d958bfa41dad310a4c64e99c1ce9215f51d"
+checksum = "c702724a350d3e247cc8304ebade6f9b488672f7678cae4b38e7715e029504de"
 dependencies = [
  "chrono",
- "http 1.1.0",
+ "http",
  "int-enum",
  "serde",
  "serde_json",
@@ -1107,9 +1180,9 @@ dependencies = [
 
 [[package]]
 name = "reduct-rs"
-version = "1.9.5"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "104a9c4002ed78139aa06837a107b77fc036b7d573e5c75c63a0638872a096f8"
+checksum = "c5afa478cb97980df15019fbead7b24c3ffe67f02cb5b617f8afc79a761c2925"
 dependencies = [
  "async-channel",
  "async-stream",
@@ -1117,7 +1190,7 @@ dependencies = [
  "chrono",
  "futures",
  "futures-util",
- "http 1.1.0",
+ "http",
  "reduct-base",
  "reqwest",
  "rustls",
@@ -1163,20 +1236,20 @@ checksum = "e898588f33fdd5b9420719948f9f2a32c922a246964576f71ba7f24f80610fbc"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
 dependencies = [
  "base64",
  "bytes",
- "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http 0.2.12",
+ "http",
  "http-body",
+ "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-util",
  "ipnet",
  "js-sys",
  "log",
@@ -1184,13 +1257,14 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
  "rustls",
  "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -1255,6 +1329,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1269,7 +1349,7 @@ version = "0.38.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1278,32 +1358,42 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
+version = "0.23.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
 dependencies = [
- "log",
+ "once_cell",
  "ring",
+ "rustls-pki-types",
  "rustls-webpki",
- "sct",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.4"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
 dependencies = [
  "base64",
+ "rustls-pki-types",
 ]
 
 [[package]]
-name = "rustls-webpki"
-version = "0.101.7"
+name = "rustls-pki-types"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
 dependencies = [
  "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -1314,16 +1404,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "semver"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1331,18 +1411,18 @@ checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1351,9 +1431,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.115"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "itoa",
  "ryu",
@@ -1397,6 +1477,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
 name = "socket2"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1417,6 +1503,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d0208408ba0c3df17ed26eb06992cb1a1268d41b2c0e12e65203fbe3972cee5"
 
 [[package]]
 name = "syn"
@@ -1442,30 +1534,9 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "tabled"
@@ -1590,11 +1661,12 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
  "rustls",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -1658,6 +1730,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1670,7 +1763,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1860,9 +1965,12 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.4"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "winapi"
@@ -2047,9 +2155,9 @@ dependencies = [
 
 [[package]]
 name = "winreg"
-version = "0.50.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://reduct.store/docs/guides"
 description = "A CLI client for ReductStore written in Rust"
 
 [dependencies]
-reduct-rs = "1.9.3"
+reduct-rs = "1.10.1"
 clap = { version = "4.5.1", features = ["cargo"] }
 dirs = "5.0.1"
 toml = "0.8.10"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ blob data.
 
 ## Features
 
-* Support for ReductStore API v1.9
+* Support for ReductStore API v1.10
 * Easy management of buckets, tokens and replications
 * Ability to check the status of a storage engine
 * Aliases for storing server credentials
@@ -60,7 +60,7 @@ Check with our [demo server](https://play.reduct.store):
 reduct-cli alias add play -L  https://play.reduct.store -t reductstore
 reduct-cli server status play
 reduct-cli bucket ls --full play
-reduct-cli cp play/datasets .
+reduct-cli cp play/datasets ./datasets --limit 100
 ```
 
 For more examples, see the [Guides](https://reduct.store/docs/guides) section in the ReductStore documentation.

--- a/src/cmd/bucket/ls.rs
+++ b/src/cmd/bucket/ls.rs
@@ -124,14 +124,14 @@ mod tests {
         let bucket = client.create_bucket(&bucket.await).send().await.unwrap();
         bucket
             .write_record("test")
-            .data("data".into())
+            .data("data")
             .timestamp_us(0)
             .send()
             .await
             .unwrap();
         bucket
             .write_record("test")
-            .data("data".into())
+            .data("data")
             .timestamp_us(1000)
             .send()
             .await

--- a/src/cmd/bucket/show.rs
+++ b/src/cmd/bucket/show.rs
@@ -173,14 +173,14 @@ mod tests {
         let bucket = client.create_bucket(&bucket_name).send().await.unwrap();
         bucket
             .write_record("test")
-            .data("data".into())
+            .data("data")
             .timestamp_us(1)
             .send()
             .await
             .unwrap();
         bucket
             .write_record("test")
-            .data("data".into())
+            .data("data")
             .timestamp_us(1000)
             .send()
             .await

--- a/src/cmd/cp.rs
+++ b/src/cmd/cp.rs
@@ -74,6 +74,25 @@ pub(crate) fn cp_cmd() -> Command {
                 .required(false)
                 .action(SetTrue)
         )
+        .arg(
+            Arg::new("each-n")
+                .long("each-n")
+                .short('N')
+                .help("Export every nth record.\nIf not specified, all records will be exported.")
+                .value_name("NUMBER")
+                .value_parser(value_parser!(u64))
+                .required(false)
+        )
+        .arg(
+            Arg::new("each-s")
+                .long("each-s")
+                .short('S')
+                .help("Export a record every n seconds.\nIf not specified, all records will be exported.")
+                .value_name("NUMBER")
+                .value_parser(value_parser!(f64))
+                .required(false)
+
+        )
 }
 
 pub(crate) async fn cp_handler(ctx: &CliContext, args: &clap::ArgMatches) -> anyhow::Result<()> {

--- a/src/cmd/cp.rs
+++ b/src/cmd/cp.rs
@@ -11,7 +11,9 @@ use crate::cmd::cp::b2b::cp_bucket_to_bucket;
 use crate::cmd::cp::b2f::cp_bucket_to_folder;
 use crate::cmd::ALIAS_OR_URL_HELP;
 use crate::context::CliContext;
-use crate::parse::widely_used_args::{make_entries_arg, make_exclude_arg, make_include_arg};
+use crate::parse::widely_used_args::{
+    make_each_n, make_each_s, make_entries_arg, make_exclude_arg, make_include_arg,
+};
 use crate::parse::ResourcePathParser;
 use clap::ArgAction::SetTrue;
 use clap::{value_parser, Arg, Command};
@@ -49,6 +51,8 @@ pub(crate) fn cp_cmd() -> Command {
         .arg(make_include_arg())
         .arg(make_exclude_arg())
         .arg(make_entries_arg())
+        .arg(make_each_n())
+        .arg(make_each_s())
         .arg(
             Arg::new("limit")
                 .long("limit")
@@ -73,25 +77,6 @@ pub(crate) fn cp_cmd() -> Command {
                 .help("Export the metadata of the records along with the records in JSON format.\nIf not specified, only the records will be exported.")
                 .required(false)
                 .action(SetTrue)
-        )
-        .arg(
-            Arg::new("each-n")
-                .long("each-n")
-                .short('N')
-                .help("Export every nth record.\nIf not specified, all records will be exported.")
-                .value_name("NUMBER")
-                .value_parser(value_parser!(u64))
-                .required(false)
-        )
-        .arg(
-            Arg::new("each-s")
-                .long("each-s")
-                .short('S')
-                .help("Export a record every n seconds.\nIf not specified, all records will be exported.")
-                .value_name("NUMBER")
-                .value_parser(value_parser!(f64))
-                .required(false)
-
         )
 }
 

--- a/src/cmd/replica/show.rs
+++ b/src/cmd/replica/show.rs
@@ -74,9 +74,16 @@ pub(super) async fn show_replica_handler(
     );
     output!(
         ctx,
-        "Errors (hourly):     {:<20} Exclude:               {:?}\n",
+        "Errors (hourly):     {:<20} Exclude:               {:?}",
         replica.diagnostics.hourly.errored,
         replica.settings.exclude
+    );
+
+    output!(
+        ctx,
+        "                                          Each Nth: {:<5?},        Each Sec: {:<5?}\n",
+        replica.settings.each_n,
+        replica.settings.each_s
     );
 
     let table = Table::new(
@@ -127,13 +134,7 @@ mod tests {
         build_client(&context, "local").await.unwrap();
 
         assert_eq!(show_replica_handler(&context, &args).await.unwrap(), ());
-        assert_eq!(context.stdout().history(), vec!["Name:                test_replica         Source Bucket:         test_bucket",
-                                                    "Active:              false                Destination Bucket:    test_bucket_2",
-                                                    "Provisioned:         false                Destination Server:    http://localhost:8383",
-                                                    "Pending Records:     0                    Entries:               []",
-                                                    "Ok Records (hourly): 0                    Include:               {}",
-                                                    "Errors (hourly):     0                    Exclude:               {}\n",
-                                                    "| Error Code | Count | Last Message |\n|------------|-------|--------------|"]);
+        assert_eq!(context.stdout().history(), vec!["Name:                test_replica         Source Bucket:         test_bucket", "Active:              false                Destination Bucket:    test_bucket_2", "Provisioned:         false                Destination Server:    http://localhost:8383", "Pending Records:     0                    Entries:               []", "Ok Records (hourly): 0                    Include:               {}", "Errors (hourly):     0                    Exclude:               {}", "                                          Each Nth: None,        Each Sec: None\n", "| Error Code | Count | Last Message |\n|------------|-------|--------------|"]);
     }
 
     #[rstest]

--- a/src/cmd/replica/update.rs
+++ b/src/cmd/replica/update.rs
@@ -280,6 +280,8 @@ mod tests {
                 dst_token: current_token,
                 include: Labels::from_iter(vec![("key1".to_string(), "value1".to_string())]),
                 exclude: Labels::from_iter(vec![("key2".to_string(), "value2".to_string())]),
+                each_n: None,
+                each_s: None,
                 entries: vec!["entry1".to_string(), "entry2".to_string()],
             }
         }

--- a/src/cmd/replica/update.rs
+++ b/src/cmd/replica/update.rs
@@ -7,7 +7,8 @@ use crate::cmd::RESOURCE_PATH_HELP;
 use crate::context::CliContext;
 use crate::io::reduct::{build_client, parse_url_and_token};
 use crate::parse::widely_used_args::{
-    make_entries_arg, make_exclude_arg, make_include_arg, parse_label_args,
+    make_each_n, make_each_s, make_entries_arg, make_exclude_arg, make_include_arg,
+    parse_label_args,
 };
 use crate::parse::ResourcePathParser;
 
@@ -40,6 +41,8 @@ pub(super) fn update_replica_cmd() -> Command {
         .arg(make_include_arg())
         .arg(make_exclude_arg())
         .arg(make_entries_arg())
+        .arg(make_each_n())
+        .arg(make_each_s())
 }
 
 pub(super) async fn update_replica_handler(
@@ -78,6 +81,8 @@ fn update_replication_settings(
 
     let include = parse_label_args(args.get_many::<String>("include"))?;
     let exclude = parse_label_args(args.get_many::<String>("exclude"))?;
+    let each_n = args.get_one::<u64>("each-n");
+    let each_s = args.get_one::<f64>("each-s");
 
     let (dest_url, token) = parse_url_and_token(ctx, &dest_alias_or_url)?;
     current_settings.dst_bucket = dest_bucket_name.clone();
@@ -99,6 +104,15 @@ fn update_replication_settings(
     if let Some(entries_filter) = entries_filter {
         current_settings.entries = entries_filter;
     }
+
+    if let Some(each_n) = each_n {
+        current_settings.each_n = Some(*each_n);
+    }
+
+    if let Some(each_s) = each_s {
+        current_settings.each_s = Some(*each_s);
+    }
+
     Ok(current_settings)
 }
 
@@ -133,6 +147,10 @@ mod tests {
                 format!("local/{}", &bucket2).as_str(),
                 "--include",
                 "key1=value2",
+                "--each-n",
+                "10",
+                "--each-s",
+                "0.5",
             ])
             .unwrap();
 
@@ -149,6 +167,8 @@ mod tests {
         );
         assert!(replica.settings.exclude.is_empty());
         assert!(replica.settings.entries.is_empty());
+        assert_eq!(replica.settings.each_n, Some(10));
+        assert_eq!(replica.settings.each_s, Some(0.5));
     }
 
     mod update_settings {

--- a/src/parse/widely_used_args.rs
+++ b/src/parse/widely_used_args.rs
@@ -4,7 +4,7 @@
 //    file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use clap::parser::ValuesRef;
-use clap::Arg;
+use clap::{value_parser, Arg};
 use reduct_rs::Labels;
 
 pub(crate) fn make_include_arg() -> Arg {
@@ -24,6 +24,26 @@ pub(crate) fn make_exclude_arg() -> Arg {
         .value_name("KEY=VALUE")
         .help("These records which have this key-value pair will not be exported.\nThe format is key=value. This option can be used multiple times to exclude multiple key-value pairs.")
         .num_args(0..)
+        .required(false)
+}
+
+pub(crate) fn make_each_n() -> Arg {
+    Arg::new("each-n")
+        .long("each-n")
+        .short('N')
+        .help("Export every nth record.\nIf not specified, all records will be exported.")
+        .value_name("NUMBER")
+        .value_parser(value_parser!(u64))
+        .required(false)
+}
+
+pub(crate) fn make_each_s() -> Arg {
+    Arg::new("each-s")
+        .long("each-s")
+        .short('S')
+        .help("Export a record every n seconds.\nIf not specified, all records will be exported.")
+        .value_name("NUMBER")
+        .value_parser(value_parser!(f64))
         .required(false)
 }
 


### PR DESCRIPTION
Close #.

### Please check that the PR meets these requirements

- [x] Tests for the changes have been added (for bug fixes / features) 
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What has changed?

* Added `each-n` and `each-s` options to the `reduct-cli cp` command.
* Added  `each-n` and `each-s` options to the `reduct-cli replica` command.

### Related Issues

No

### Does this PR introduce a breakthrough change?

No

### Other information: