### PR TITLE
Print all errors in progress  of `reduct-cli cp` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed:
+
+- Print all errors in progress of reduct-cli cp command, [PR-12](https://github.com/reductstore/reduct-cli/pull/12)
+
 ## [0.3.0]
 
 ### Added:


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

We used to stop tasks in the progress bar without printing error message. Now we print the error and abandon the task:

```
[00:00:37] #####----------------------------------- 10.464% [InternalServerError] Input/output error (os error 5)
[00:00:41] #--------------------------------------- 2.451 % [InternalServerError] Input/output error (os error 5)
[00:00:43] ###########----------------------------- 26.230% Copying mnist_training (4.1 MB, 167.1 KB/s)   
```

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
