### PR TITLE
RS-518: Fix progress bar status for limited query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed:
 
-- RS-357: Print an error message if SSL certificate is invalid, [PR-13](https://github.com/reductstore/reduct-cli/pull/19)
+- RS-357: Print an error message if SSL certificate is invalid, [PR-19](https://github.com/reductstore/reduct-cli/pull/19)
+- RS-518: Progress bar status for limited query, [PR-20](https://github.com/reductstore/reduct-cli/pull/20)
 
 ## [0.3.1] - 2024-07-19
 

--- a/src/cmd/bucket/ls.rs
+++ b/src/cmd/bucket/ls.rs
@@ -140,13 +140,14 @@ mod tests {
 
         ls_bucket(&context, &args).await.unwrap();
 
-        assert_eq!(context
+        assert_eq!(*context
                        .stdout()
-                       .history(),
-                   vec!["| Name          | Entries | Size | Oldest record (UTC)      | Latest record (UTC)      |\n\
-                   |---------------|---------|------|--------------------------|--------------------------|\n\
-                   | test_bucket   | 1       | 74 B | 1970-01-01T00:00:00.000Z | 1970-01-01T00:00:00.001Z |\n\
-                   | test_bucket_2 | 0       | 0 B  | ---                      | ---                      |"]
-        );
+                       .history()
+                       .get(0)
+                       .unwrap(),
+                   vec!["| Name          | Entries | Size | Oldest record (UTC)      | Latest record (UTC)      |",
+                        "|---------------|---------|------|--------------------------|--------------------------|",
+                        "| test_bucket   | 1       | 74 B | 1970-01-01T00:00:00.000Z | 1970-01-01T00:00:00.001Z |",
+                        "| test_bucket_2 | 0       | 0 B  | ---                      | ---                      |"].join("\n"));
     }
 }

--- a/src/cmd/cp/helpers.rs
+++ b/src/cmd/cp/helpers.rs
@@ -317,10 +317,10 @@ fn init_task_progress_bar(
 ) -> (Option<u64>, ProgressBar) {
     let limit = query_params.limit;
     let sty = ProgressStyle::with_template(
-        "[{elapsed_precise}, ETA {eta_precise}] {bar:40.cyan/blue} {percent_precise:6}% {msg}",
+        "[{elapsed_precise}, ETA {eta_precise}] {bar:40.green/gray} {percent_precise:6}% {msg}",
     )
-    .unwrap()
-    .progress_chars("##-");
+    .unwrap();
+    // .progress_chars("##-");
 
     if let Some(limit) = limit {
         // progress for limited copying


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The `reduct-cli cp` command with the `--limit` flag showed the progress bar for the entire time range. I've refactored this part by adding the condition for the limited request and using the number of records instead of the time range.

Additionally, I've improved the style and message of the progress bar.

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
