### PR TITLE
RS-508: Add --only-entry option to rename an entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added:
 
 - RS-507: `bucket rename` command, [PR-21](https://github.com/reductstore/reduct-cli/pull/21)
+- RS-508: Add `--only-entry` option to rename an entry, [PR-22](https://github.com/reductstore/reduct-cli/pull/22)
 
 ### Fixed:
 

--- a/src/cmd/cp/helpers.rs
+++ b/src/cmd/cp/helpers.rs
@@ -111,7 +111,7 @@ impl TransferProgress {
     }
 
     pub(crate) fn print_error(&self, err: String) {
-        self.progress_bar.set_message(format!("Error: {}", err));
+        self.progress_bar.set_message(format!("{}", err));
         self.progress_bar.abandon();
     }
 

--- a/src/cmd/cp/helpers.rs
+++ b/src/cmd/cp/helpers.rs
@@ -260,7 +260,7 @@ where
             macro_rules! print_error_progress {
                 ($err:expr) => {{
                     transfer_progress.print_error($err.to_string());
-                    return Err($err);
+                    Err($err)
                 }};
             }
             let _permit = local_sem.acquire().await.unwrap();


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

Add the `--only-entry` option to the `bucket rename` command for renaming an entry.

### Related issues

#21 

### Does this PR introduce a breaking change?

No

### Other information:
