### PR TITLE
RS-451: Add reduct-cli rm command for removing records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added:
 
 - RS-507: `bucket rename` command, [PR-21](https://github.com/reductstore/reduct-cli/pull/21)
-- RS-508: Add `--only-entry` option to rename an entry, [PR-22](https://github.com/reductstore/reduct-cli/pull/22)
+- RS-508: `--only-entry` option to rename an entry, [PR-22](https://github.com/reductstore/reduct-cli/pull/22)
+- RS-451: `reduct-cli rm` command for removing records`, [PR-25](https://github.com/reductstore/reduct-cli/pull/25)
 
 ### Fixed:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1177,9 +1177,9 @@ dependencies = [
 
 [[package]]
 name = "reduct-rs"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f155e5331e4e3610480fdcec9927b8232d171fd7a64c0591cf047ffee55aaa2"
+checksum = "1ab257da6a91567311872726c73ae0c7310239e4fa4a93635e2d9a8d86dca53d"
 dependencies = [
  "async-channel",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://reduct.store/docs/guides"
 description = "A CLI client for ReductStore written in Rust"
 
 [dependencies]
-reduct-rs = "1.12.0"
+reduct-rs = "1.12.1"
 clap = { version = "4.5.1", features = ["cargo"] }
 dirs = "5.0.1"
 toml = "0.8.10"

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -6,6 +6,7 @@ pub(crate) mod alias;
 pub(crate) mod bucket;
 pub(crate) mod cp;
 pub(crate) mod replica;
+pub(crate) mod rm;
 pub(crate) mod server;
 pub(crate) mod token;
 

--- a/src/cmd/cp/b2b.rs
+++ b/src/cmd/cp/b2b.rs
@@ -3,9 +3,10 @@
 //    License, v. 2.0. If a copy of the MPL was not distributed with this
 //    file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::cmd::cp::helpers::{parse_query_params, start_loading, CopyVisitor};
+use crate::cmd::cp::helpers::{start_loading, CopyVisitor};
 use crate::context::CliContext;
 use crate::io::reduct::build_client;
+use crate::parse::parse_query_params;
 use clap::ArgMatches;
 use reduct_rs::{Bucket, ErrorCode, Record, ReductError};
 use std::sync::Arc;

--- a/src/cmd/cp/b2f.rs
+++ b/src/cmd/cp/b2f.rs
@@ -3,7 +3,7 @@
 //    License, v. 2.0. If a copy of the MPL was not distributed with this
 //    file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::cmd::cp::helpers::{parse_query_params, start_loading, CopyVisitor};
+use crate::cmd::cp::helpers::{start_loading, CopyVisitor};
 use crate::context::CliContext;
 use crate::io::reduct::build_client;
 use clap::ArgMatches;
@@ -15,6 +15,7 @@ use std::path::PathBuf;
 
 use tokio::io::AsyncWriteExt;
 
+use crate::parse::parse_query_params;
 use tokio::{fs, pin};
 
 struct CopyToFolderVisitor {

--- a/src/cmd/cp/helpers.rs
+++ b/src/cmd/cp/helpers.rs
@@ -16,38 +16,8 @@ use tokio::task::JoinSet;
 use tokio::time::{sleep, Instant};
 
 use crate::context::CliContext;
-use crate::parse::fetch_and_filter_entries;
 use crate::parse::widely_used_args::parse_label_args;
-
-pub(super) struct QueryParams {
-    start: Option<i64>,
-    stop: Option<i64>,
-    include_labels: Labels,
-    exclude_labels: Labels,
-    each_n: Option<u64>,
-    each_s: Option<f64>,
-    limit: Option<u64>,
-    entry_filter: Vec<String>,
-    parallel: usize,
-    ttl: Duration,
-}
-
-impl Default for QueryParams {
-    fn default() -> Self {
-        Self {
-            start: None,
-            stop: None,
-            include_labels: Labels::new(),
-            exclude_labels: Labels::new(),
-            each_n: None,
-            each_s: None,
-            limit: None,
-            entry_filter: Vec::new(),
-            parallel: 1,
-            ttl: Duration::from_secs(60),
-        }
-    }
-}
+use crate::parse::{fetch_and_filter_entries, parse_time, QueryParams};
 
 pub(super) struct TransferProgress {
     entry: EntryInfo,
@@ -137,59 +107,6 @@ impl TransferProgress {
             ByteSize::b(self.speed)
         )
     }
-}
-
-pub(super) fn parse_query_params(
-    ctx: &CliContext,
-    args: &ArgMatches,
-) -> anyhow::Result<QueryParams> {
-    let start = parse_time(args.get_one::<String>("start"))?;
-    let stop = parse_time(args.get_one::<String>("stop"))?;
-    let include_labels = parse_label_args(args.get_many::<String>("include"))?.unwrap_or_default();
-    let exclude_labels = parse_label_args(args.get_many::<String>("exclude"))?.unwrap_or_default();
-    let each_n = args.get_one::<u64>("each-n").map(|n| *n);
-    let each_s = args.get_one::<f64>("each-s").map(|s| *s);
-    let limit = args.get_one::<u64>("limit").map(|limit| *limit);
-
-    let entries_filter = args
-        .get_many::<String>("entries")
-        .unwrap_or_default()
-        .map(|s| s.to_string())
-        .collect::<Vec<String>>();
-
-    Ok(QueryParams {
-        start,
-        stop,
-        include_labels,
-        exclude_labels,
-        each_n,
-        each_s,
-        limit,
-        entry_filter: entries_filter,
-        parallel: ctx.parallel(),
-        ttl: ctx.timeout() * ctx.parallel() as u32,
-    })
-}
-
-pub(super) fn parse_time(time_str: Option<&String>) -> anyhow::Result<Option<i64>> {
-    if time_str.is_none() {
-        return Ok(None);
-    }
-
-    let time_str = time_str.unwrap();
-    let time = if let Ok(time) = time_str.parse::<i64>() {
-        if time < 0 {
-            return Err(anyhow::anyhow!("Time must be a positive integer"));
-        }
-        time
-    } else {
-        // try parse as ISO 8601
-        DateTime::parse_from_rfc3339(time_str)
-            .map_err(|err| anyhow::anyhow!("Failed to parse time {}: {}", time_str, err))?
-            .timestamp_micros()
-    };
-
-    Ok(Some(time))
 }
 
 fn build_query(src_bucket: &Bucket, entry: &EntryInfo, query_params: &QueryParams) -> QueryBuilder {
@@ -320,7 +237,6 @@ fn init_task_progress_bar(
         "[{elapsed_precise}, ETA {eta_precise}] {bar:40.green/gray} {percent_precise:6}% {msg}",
     )
     .unwrap();
-    // .progress_chars("##-");
 
     if let Some(limit) = limit {
         // progress for limited copying
@@ -356,145 +272,6 @@ mod tests {
     use rstest::*;
 
     use super::*;
-
-    mod parse_query_params {
-        use crate::cmd::cp::cp_cmd;
-        use crate::context::tests::context;
-
-        use super::*;
-
-        #[rstest]
-        fn parse_start_stop(context: CliContext) {
-            let args = cp_cmd()
-                .try_get_matches_from(vec!["cp", "serv/buck1", "serv/buck2"])
-                .unwrap();
-            let query_params = parse_query_params(&context, &args).unwrap();
-
-            assert_eq!(query_params.start, None);
-            assert_eq!(query_params.stop, None);
-        }
-
-        #[rstest]
-        fn parse_start_stop_with_values(context: CliContext) {
-            let args = cp_cmd()
-                .try_get_matches_from(vec![
-                    "cp",
-                    "serv/buck1",
-                    "serv/buck2",
-                    "--start",
-                    "100",
-                    "--stop",
-                    "200",
-                ])
-                .unwrap();
-            let query_params = parse_query_params(&context, &args).unwrap();
-
-            assert_eq!(query_params.start, Some(100));
-            assert_eq!(query_params.stop, Some(200));
-        }
-
-        #[rstest]
-        fn parse_start_stop_iso8601(context: CliContext) {
-            let args = cp_cmd()
-                .try_get_matches_from(vec![
-                    "cp",
-                    "serv/buck1",
-                    "serv/buck2",
-                    "--start",
-                    "2023-01-01T00:00:00Z",
-                    "--stop",
-                    "2023-01-02T00:00:00Z",
-                ])
-                .unwrap();
-            let query_params = parse_query_params(&context, &args).unwrap();
-
-            assert_eq!(query_params.start, Some(1672531200000000));
-            assert_eq!(query_params.stop, Some(1672617600000000));
-        }
-
-        #[rstest]
-        fn parse_include_exclude(context: CliContext) {
-            let args = cp_cmd()
-                .try_get_matches_from(vec![
-                    "cp",
-                    "serv/buck1",
-                    "serv/buck2",
-                    "--include",
-                    "key1=value1",
-                    "key2=value2",
-                    "--exclude",
-                    "key3=value3",
-                    "key4=value4",
-                ])
-                .unwrap();
-            let query_params = parse_query_params(&context, &args).unwrap();
-
-            assert_eq!(
-                query_params.include_labels,
-                Labels::from_iter(vec![
-                    ("key1".to_string(), "value1".to_string()),
-                    ("key2".to_string(), "value2".to_string()),
-                ])
-            );
-            assert_eq!(
-                query_params.exclude_labels,
-                Labels::from_iter(vec![
-                    ("key3".to_string(), "value3".to_string()),
-                    ("key4".to_string(), "value4".to_string()),
-                ])
-            );
-        }
-
-        #[rstest]
-        fn parse_each_n(context: CliContext) {
-            let args = cp_cmd()
-                .try_get_matches_from(vec!["cp", "serv/buck1", "serv/buck2", "--each-n", "10"])
-                .unwrap();
-            let query_params = parse_query_params(&context, &args).unwrap();
-
-            assert_eq!(query_params.each_n, Some(10));
-        }
-
-        #[rstest]
-        fn parse_each_s(context: CliContext) {
-            let args = cp_cmd()
-                .try_get_matches_from(vec!["cp", "serv/buck1", "serv/buck2", "--each-s", "10"])
-                .unwrap();
-            let query_params = parse_query_params(&context, &args).unwrap();
-
-            assert_eq!(query_params.each_s, Some(10.0));
-        }
-
-        #[rstest]
-        fn parse_limit(context: CliContext) {
-            let args = cp_cmd()
-                .try_get_matches_from(vec!["cp", "serv/buck1", "serv/buck2", "--limit", "100"])
-                .unwrap();
-            let query_params = parse_query_params(&context, &args).unwrap();
-
-            assert_eq!(query_params.limit, Some(100));
-        }
-
-        #[rstest]
-        fn parse_entries_filter(context: CliContext) {
-            let args = cp_cmd()
-                .try_get_matches_from(vec![
-                    "cp",
-                    "serv/buck1",
-                    "serv/buck2",
-                    "--entries",
-                    "entry-1",
-                    "entry-2",
-                ])
-                .unwrap();
-            let query_params = parse_query_params(&context, &args).unwrap();
-
-            assert_eq!(
-                query_params.entry_filter,
-                vec![String::from("entry-1"), String::from("entry-2")]
-            );
-        }
-    }
 
     mod downloading {
         use async_trait::async_trait;

--- a/src/cmd/cp/helpers.rs
+++ b/src/cmd/cp/helpers.rs
@@ -7,17 +7,13 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use bytesize::ByteSize;
-use chrono::DateTime;
-use clap::ArgMatches;
 use futures_util::StreamExt;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
-use reduct_rs::{Bucket, EntryInfo, ErrorCode, Labels, QueryBuilder, Record, ReductError};
+use reduct_rs::{Bucket, EntryInfo, ErrorCode, QueryBuilder, Record, ReductError};
 use tokio::task::JoinSet;
 use tokio::time::{sleep, Instant};
 
-use crate::context::CliContext;
-use crate::parse::widely_used_args::parse_label_args;
-use crate::parse::{fetch_and_filter_entries, parse_time, QueryParams};
+use crate::parse::{fetch_and_filter_entries, QueryParams};
 
 pub(super) struct TransferProgress {
     entry: EntryInfo,
@@ -274,14 +270,14 @@ mod tests {
     use super::*;
 
     mod downloading {
+        use crate::context::tests::{bucket, context};
+        use crate::context::CliContext;
+        use crate::io::reduct::build_client;
         use async_trait::async_trait;
         use bytes::Bytes;
         use mockall::mock;
         use mockall::predicate::{always, eq};
-
-        use crate::context::tests::{bucket, context};
-        use crate::context::CliContext;
-        use crate::io::reduct::build_client;
+        use reduct_rs::Labels;
 
         use super::*;
 

--- a/src/cmd/rm.rs
+++ b/src/cmd/rm.rs
@@ -1,0 +1,163 @@
+// Copyright 2024 ReductStore
+// This Source Code Form is subject to the terms of the Mozilla Public
+//    License, v. 2.0. If a copy of the MPL was not distributed with this
+//    file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use crate::cmd::ALIAS_OR_URL_HELP;
+use crate::context::CliContext;
+use crate::io::reduct::build_client;
+use crate::parse::widely_used_args::{
+    make_each_n, make_each_s, make_entries_arg, make_exclude_arg, make_include_arg,
+};
+use crate::parse::{
+    fetch_and_filter_entries, parse_query_params, parse_time, QueryParams, ResourcePathParser,
+};
+use clap::ArgAction::SetTrue;
+use clap::{value_parser, Arg, Command};
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use reduct_rs::{Bucket, EntryInfo, QueryBuilder, RemoveQueryBuilder, RemoveRecordBuilder};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::task::JoinSet;
+
+pub(crate) fn rm_cmd() -> Command {
+    Command::new("rm")
+        .about("Remove data from a bucket")
+        .arg_required_else_help(true)
+        .arg(
+            Arg::new("BUCKET_PATH")
+                .help(ALIAS_OR_URL_HELP)
+                .value_parser(ResourcePathParser::new())
+                .required(true),
+        )
+        .arg(
+            Arg::new("start")
+                .long("start")
+                .short('b')
+                .help("Remove records  with timestamps older than this time point in ISO format or Unix timestamp in microseconds.\nIf not specified, the export will start from the first record in an entry.")
+                .required(false)
+        )
+        .arg(
+            Arg::new("stop")
+                .long("stop")
+                .short('e')
+                .help("Remove records with timestamps newer than this time point in ISO format or Unix timestamp in microseconds.\nIf not specified, the export will end at the last record in an entry.")
+                .required(false)
+        )
+        .arg(make_include_arg())
+        .arg(make_exclude_arg())
+        .arg(make_entries_arg())
+        .arg(make_each_n())
+        .arg(make_each_s())
+}
+
+pub(crate) async fn rm_handler(ctx: &CliContext, args: &clap::ArgMatches) -> anyhow::Result<()> {
+    let (alias, bucket) = args.get_one::<(String, String)>("BUCKET_PATH").unwrap();
+
+    let query_params = parse_query_params(ctx, &args)?;
+
+    let client = build_client(ctx, &alias).await?;
+    let bucket = client.get_bucket(&bucket).await?;
+    let entries = fetch_and_filter_entries(&bucket, &query_params.entry_filter).await?;
+
+    let mut tasks = JoinSet::new();
+    let progress = MultiProgress::new();
+
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(query_params.parallel));
+
+    for entry in entries {
+        let mut query_builder = build_query(&bucket, &entry, &query_params);
+        let local_sem = Arc::clone(&semaphore);
+
+        let spinner = progress.add(ProgressBar::new_spinner());
+
+        tasks.spawn(async move {
+            spinner.enable_steady_tick(Duration::from_millis(120));
+            spinner.set_style(
+                ProgressStyle::with_template("[{elapsed_precise}] {spinner:.green} {msg}")
+                    .unwrap()
+                    // For more spinners check out the cli-spinners project:
+                    // https://github.com/sindresorhus/cli-spinners/blob/master/spinners.json
+                    .tick_strings(&["▁", "▃", "▄", "▅", "▆", "▇"]),
+            );
+            spinner.set_message(format!("Removing records from '{}'", entry.name));
+
+            let _permit = local_sem.acquire().await.unwrap();
+            match query_builder.send().await {
+                Ok(removed_records) => {
+                    spinner.finish_with_message(format!(
+                        "Removed {} records from '{}'",
+                        removed_records, entry.name
+                    ));
+                }
+                Err(err) => {
+                    spinner.finish_with_message(format!(
+                        "Failed to remove records from '{}': {}",
+                        entry.name, err
+                    ));
+                }
+            }
+        });
+    }
+
+    while let Some(result) = tasks.join_next().await {
+        let _ = result?;
+    }
+
+    Ok(())
+}
+
+fn build_query(
+    src_bucket: &Bucket,
+    entry: &EntryInfo,
+    query_params: &QueryParams,
+) -> RemoveQueryBuilder {
+    let mut query_builder = src_bucket.remove_query(&entry.name);
+    if let Some(start) = query_params.start {
+        query_builder = query_builder.start_us(start as u64);
+    }
+
+    if let Some(stop) = query_params.stop {
+        query_builder = query_builder.stop_us(stop as u64);
+    }
+
+    if let Some(each_n) = query_params.each_n {
+        query_builder = query_builder.each_n(each_n);
+    }
+
+    if let Some(each_s) = query_params.each_s {
+        query_builder = query_builder.each_s(each_s);
+    }
+
+    query_builder = query_builder.include(query_params.include_labels.clone());
+    query_builder = query_builder.exclude(query_params.exclude_labels.clone());
+
+    query_builder
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::tests::context;
+    use rstest::*;
+
+    #[rstest]
+    #[tokio::test]
+    async fn folder_to_folder_unsupported(context: CliContext) {
+        let args = cp_cmd()
+            .try_get_matches_from(vec!["cp", "./", "./"])
+            .unwrap();
+        let result = cp_handler(&context, &args).await;
+        assert!(result.is_err());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn folder_to_bucket_unsupported(context: CliContext) {
+        let args = cp_cmd()
+            .try_get_matches_from(vec!["cp", "./", "local/bucket"])
+            .unwrap();
+        let result = cp_handler(&context, &args).await;
+        assert!(result.is_err());
+    }
+}

--- a/src/cmd/rm.rs
+++ b/src/cmd/rm.rs
@@ -19,7 +19,6 @@ use async_trait::async_trait;
 use clap::{Arg, Command};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use reduct_rs::{Bucket, EntryInfo};
-use serde::de::Visitor;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::task::JoinSet;

--- a/src/cmd/rm/batch_remover.rs
+++ b/src/cmd/rm/batch_remover.rs
@@ -1,0 +1,107 @@
+// Copyright 2024 ReductStore
+// This Source Code Form is subject to the terms of the Mozilla Public
+//    License, v. 2.0. If a copy of the MPL was not distributed with this
+//    file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use crate::cmd::rm::RemoveRecords;
+use crate::parse::parse_time;
+use async_trait::async_trait;
+use reduct_rs::{Bucket, EntryInfo};
+
+/// Remove records from a bucket using a list of timestamps
+pub(super) struct BatchRemover {
+    bucket: Bucket,
+    timestamps: Vec<String>,
+}
+
+#[async_trait]
+impl RemoveRecords for BatchRemover {
+    async fn remove_records(&self, entry: EntryInfo) -> anyhow::Result<u64> {
+        let mut batch = self.bucket.remove_batch(&entry.name);
+        for timestamp in &self.timestamps {
+            batch.append_timestamp_us(parse_time(Some(timestamp))?.unwrap());
+        }
+
+        let error_map = batch.send().await?;
+        Ok(self.timestamps.len() as u64 - error_map.len() as u64)
+    }
+}
+impl BatchRemover {
+    pub fn new(bucket: Bucket, timestamps: Vec<String>) -> Self {
+        Self { bucket, timestamps }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::cmd::rm::batch_remover::BatchRemover;
+    use crate::cmd::rm::tests::bucket_with_record;
+    use crate::cmd::rm::RemoveRecords;
+    use reduct_rs::{Bucket, EntryInfo};
+    use rstest::*;
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_batch_remover(#[future] bucket_with_record: Bucket) {
+        let bucket = bucket_with_record.await;
+
+        let query_remover = BatchRemover::new(bucket, vec!["100".to_string(), "150".to_string()]);
+        let entry = EntryInfo {
+            name: "entry-1".to_string(),
+            size: 0,
+            record_count: 0,
+            block_count: 0,
+            oldest_record: 0,
+            latest_record: 0,
+        };
+
+        assert_eq!(query_remover.remove_records(entry).await.unwrap(), 1);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_batch_remover_iso(#[future] bucket_with_record: Bucket) {
+        let bucket = bucket_with_record.await;
+
+        let query_remover = BatchRemover::new(
+            bucket,
+            vec!["150".to_string(), "2024-01-01T10:00:00Z".to_string()],
+        );
+        let entry = EntryInfo {
+            name: "entry-1".to_string(),
+            size: 0,
+            record_count: 0,
+            block_count: 0,
+            oldest_record: 0,
+            latest_record: 0,
+        };
+
+        assert_eq!(query_remover.remove_records(entry).await.unwrap(), 1);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_batch_wrong_time_format(#[future] bucket_with_record: Bucket) {
+        let bucket = bucket_with_record.await;
+
+        let query_remover = BatchRemover::new(bucket, vec!["xxx".to_string()]);
+        let entry = EntryInfo {
+            name: "entry-1".to_string(),
+            size: 0,
+            record_count: 0,
+            block_count: 0,
+            oldest_record: 0,
+            latest_record: 0,
+        };
+
+        assert_eq!(
+            query_remover
+                .remove_records(entry)
+                .await
+                .err()
+                .unwrap()
+                .to_string(),
+            "Failed to parse time xxx: premature end of input"
+        );
+    }
+}

--- a/src/cmd/rm/query_remover.rs
+++ b/src/cmd/rm/query_remover.rs
@@ -1,0 +1,99 @@
+// Copyright 2024 ReductStore
+// This Source Code Form is subject to the terms of the Mozilla Public
+//    License, v. 2.0. If a copy of the MPL was not distributed with this
+//    file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use crate::cmd::rm::RemoveRecords;
+use crate::parse::QueryParams;
+use async_trait::async_trait;
+use reduct_rs::{Bucket, EntryInfo, RemoveQueryBuilder};
+
+/// Remove records from a bucket using a query
+pub(super) struct QueryRemover {
+    bucket: Bucket,
+    query_params: QueryParams,
+}
+
+#[async_trait]
+impl RemoveRecords for QueryRemover {
+    async fn remove_records(&self, entry: EntryInfo) -> anyhow::Result<u64> {
+        let query_builder = self.build_query(entry);
+        let removed_records = query_builder.send().await?;
+        Ok(removed_records)
+    }
+}
+
+impl QueryRemover {
+    pub fn new(bucket: Bucket, query_params: QueryParams) -> Self {
+        Self {
+            bucket,
+            query_params,
+        }
+    }
+
+    fn build_query(&self, entry: EntryInfo) -> RemoveQueryBuilder {
+        let mut query_builder = self.bucket.remove_query(&entry.name);
+        if let Some(start) = self.query_params.start {
+            query_builder = query_builder.start_us(start as u64);
+        }
+
+        if let Some(stop) = self.query_params.stop {
+            query_builder = query_builder.stop_us(stop as u64);
+        }
+
+        if let Some(each_n) = self.query_params.each_n {
+            query_builder = query_builder.each_n(each_n);
+        }
+
+        if let Some(each_s) = self.query_params.each_s {
+            query_builder = query_builder.each_s(each_s);
+        }
+
+        query_builder = query_builder.include(self.query_params.include_labels.clone());
+        query_builder = query_builder.exclude(self.query_params.exclude_labels.clone());
+
+        query_builder
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::cmd::rm::query_remover::QueryRemover;
+    use crate::cmd::rm::tests::bucket_with_record;
+    use crate::cmd::rm::RemoveRecords;
+    use crate::context::tests::bucket;
+    use crate::parse::QueryParams;
+    use reduct_rs::{Bucket, EntryInfo};
+    use rstest::*;
+    use std::collections::HashMap;
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_query_remover(#[future] bucket_with_record: Bucket, #[future] bucket: String) {
+        let bucket = bucket_with_record.await;
+        let query_params = QueryParams {
+            start: Some(100),
+            stop: Some(200),
+            each_n: None,
+            each_s: None,
+            limit: None,
+            entry_filter: vec![],
+            parallel: 0,
+            include_labels: HashMap::new(),
+            exclude_labels: HashMap::new(),
+            ttl: Default::default(),
+        };
+
+        let query_remover = QueryRemover::new(bucket, query_params);
+        let entry = EntryInfo {
+            name: "entry-1".to_string(),
+            size: 0,
+            record_count: 0,
+            block_count: 0,
+            oldest_record: 0,
+            latest_record: 0,
+        };
+
+        assert_eq!(query_remover.remove_records(entry).await.ok(), Some(1));
+    }
+}

--- a/src/cmd/rm/query_remover.rs
+++ b/src/cmd/rm/query_remover.rs
@@ -61,7 +61,7 @@ mod tests {
     use crate::cmd::rm::query_remover::QueryRemover;
     use crate::cmd::rm::tests::bucket_with_record;
     use crate::cmd::rm::RemoveRecords;
-    use crate::context::tests::bucket;
+
     use crate::parse::QueryParams;
     use reduct_rs::{Bucket, EntryInfo};
     use rstest::*;
@@ -69,7 +69,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_query_remover(#[future] bucket_with_record: Bucket, #[future] bucket: String) {
+    async fn test_query_remover(#[future] bucket_with_record: Bucket) {
         let bucket = bucket_with_record.await;
         let query_params = QueryParams {
             start: Some(100),

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 use crate::cmd::bucket::{bucket_cmd, bucket_handler};
 use crate::cmd::cp::{cp_cmd, cp_handler};
 use crate::cmd::replica::{replication_cmd, replication_handler};
+use crate::cmd::rm::{rm_cmd, rm_handler};
 use crate::cmd::server::{server_cmd, server_handler};
 use crate::cmd::token::{token_cmd, token_handler};
 use clap::ArgAction::SetTrue;
@@ -63,8 +64,9 @@ fn cli() -> Command {
         .subcommand(server_cmd())
         .subcommand(bucket_cmd())
         .subcommand(token_cmd())
-        .subcommand(cp_cmd())
         .subcommand(replication_cmd())
+        .subcommand(cp_cmd())
+        .subcommand(rm_cmd())
 }
 
 #[tokio::main]
@@ -83,8 +85,10 @@ async fn main() -> anyhow::Result<()> {
         Some(("server", args)) => server_handler(&ctx, args.subcommand()).await,
         Some(("bucket", args)) => bucket_handler(&ctx, args.subcommand()).await,
         Some(("token", args)) => token_handler(&ctx, args.subcommand()).await,
-        Some(("cp", args)) => cp_handler(&ctx, args).await,
         Some(("replica", args)) => replication_handler(&ctx, args.subcommand()).await,
+
+        Some(("cp", args)) => cp_handler(&ctx, args).await,
+        Some(("rm", args)) => rm_handler(&ctx, args).await,
         _ => Ok(()),
     };
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -10,6 +10,6 @@ mod resource_path;
 pub(crate) mod widely_used_args;
 
 pub(crate) use byte_size::ByteSizeParser;
-pub(crate) use helpers::fetch_and_filter_entries;
+pub(crate) use helpers::{fetch_and_filter_entries, parse_query_params, parse_time, QueryParams};
 pub(crate) use quota_type::QuotaTypeParser;
 pub(crate) use resource_path::ResourcePathParser;

--- a/src/parse/helpers.rs
+++ b/src/parse/helpers.rs
@@ -54,6 +54,7 @@ pub(crate) fn parse_time(time_str: Option<&String>) -> anyhow::Result<Option<u64
     Ok(Some(time as u64))
 }
 
+#[derive(Clone, Debug)]
 pub(crate) struct QueryParams {
     pub start: Option<u64>,
     pub stop: Option<u64>,

--- a/src/parse/helpers.rs
+++ b/src/parse/helpers.rs
@@ -3,7 +3,12 @@
 //    License, v. 2.0. If a copy of the MPL was not distributed with this
 //    file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use reduct_rs::{Bucket, EntryInfo};
+use crate::context::CliContext;
+use crate::parse::widely_used_args::parse_label_args;
+use chrono::DateTime;
+use clap::ArgMatches;
+use reduct_rs::{Bucket, EntryInfo, Labels};
+use std::time::Duration;
 
 pub(crate) async fn fetch_and_filter_entries(
     src_bucket: &Bucket,
@@ -26,4 +31,237 @@ pub(crate) async fn fetch_and_filter_entries(
         .map(|entry| entry.clone())
         .collect::<Vec<EntryInfo>>();
     Ok(entries)
+}
+
+pub(crate) fn parse_time(time_str: Option<&String>) -> anyhow::Result<Option<u64>> {
+    if time_str.is_none() {
+        return Ok(None);
+    }
+
+    let time_str = time_str.unwrap();
+    let time = if let Ok(time) = time_str.parse::<i64>() {
+        if time < 0 {
+            return Err(anyhow::anyhow!("Time must be a positive integer"));
+        }
+        time
+    } else {
+        // try parse as ISO 8601
+        DateTime::parse_from_rfc3339(time_str)
+            .map_err(|err| anyhow::anyhow!("Failed to parse time {}: {}", time_str, err))?
+            .timestamp_micros()
+    };
+
+    Ok(Some(time as u64))
+}
+
+pub(crate) struct QueryParams {
+    pub start: Option<u64>,
+    pub stop: Option<u64>,
+    pub include_labels: Labels,
+    pub exclude_labels: Labels,
+    pub each_n: Option<u64>,
+    pub each_s: Option<f64>,
+    pub limit: Option<u64>,
+    pub entry_filter: Vec<String>,
+    pub parallel: usize,
+    pub ttl: Duration,
+}
+
+impl Default for QueryParams {
+    fn default() -> Self {
+        Self {
+            start: None,
+            stop: None,
+            include_labels: Labels::new(),
+            exclude_labels: Labels::new(),
+            each_n: None,
+            each_s: None,
+            limit: None,
+            entry_filter: Vec::new(),
+            parallel: 1,
+            ttl: Duration::from_secs(60),
+        }
+    }
+}
+
+pub(crate) fn parse_query_params(
+    ctx: &CliContext,
+    args: &ArgMatches,
+) -> anyhow::Result<QueryParams> {
+    let start = parse_time(args.get_one::<String>("start"))?;
+    let stop = parse_time(args.get_one::<String>("stop"))?;
+    let include_labels = parse_label_args(args.get_many::<String>("include"))?.unwrap_or_default();
+    let exclude_labels = parse_label_args(args.get_many::<String>("exclude"))?.unwrap_or_default();
+    let each_n = args.get_one::<u64>("each-n").map(|n| *n);
+    let each_s = args.get_one::<f64>("each-s").map(|s| *s);
+
+    // arguments aren't used in all cases
+    let limit = args
+        .try_get_one::<u64>("limit")
+        .ok()
+        .unwrap_or(None)
+        .map(|n| *n);
+
+    let entries_filter = args
+        .get_many::<String>("entries")
+        .unwrap_or_default()
+        .map(|s| s.to_string())
+        .collect::<Vec<String>>();
+
+    Ok(QueryParams {
+        start,
+        stop,
+        include_labels,
+        exclude_labels,
+        each_n,
+        each_s,
+        limit,
+        entry_filter: entries_filter,
+        parallel: ctx.parallel(),
+        ttl: ctx.timeout() * ctx.parallel() as u32,
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    mod parse_query_params {
+        use crate::cmd::cp::cp_cmd;
+        use crate::context::tests::context;
+        use rstest::rstest;
+
+        use super::*;
+
+        #[rstest]
+        fn parse_start_stop(context: CliContext) {
+            let args = cp_cmd()
+                .try_get_matches_from(vec!["cp", "serv/buck1", "serv/buck2"])
+                .unwrap();
+            let query_params = parse_query_params(&context, &args).unwrap();
+
+            assert_eq!(query_params.start, None);
+            assert_eq!(query_params.stop, None);
+        }
+
+        #[rstest]
+        fn parse_start_stop_with_values(context: CliContext) {
+            let args = cp_cmd()
+                .try_get_matches_from(vec![
+                    "cp",
+                    "serv/buck1",
+                    "serv/buck2",
+                    "--start",
+                    "100",
+                    "--stop",
+                    "200",
+                ])
+                .unwrap();
+            let query_params = parse_query_params(&context, &args).unwrap();
+
+            assert_eq!(query_params.start, Some(100));
+            assert_eq!(query_params.stop, Some(200));
+        }
+
+        #[rstest]
+        fn parse_start_stop_iso8601(context: CliContext) {
+            let args = cp_cmd()
+                .try_get_matches_from(vec![
+                    "cp",
+                    "serv/buck1",
+                    "serv/buck2",
+                    "--start",
+                    "2023-01-01T00:00:00Z",
+                    "--stop",
+                    "2023-01-02T00:00:00Z",
+                ])
+                .unwrap();
+            let query_params = parse_query_params(&context, &args).unwrap();
+
+            assert_eq!(query_params.start, Some(1672531200000000));
+            assert_eq!(query_params.stop, Some(1672617600000000));
+        }
+
+        #[rstest]
+        fn parse_include_exclude(context: CliContext) {
+            let args = cp_cmd()
+                .try_get_matches_from(vec![
+                    "cp",
+                    "serv/buck1",
+                    "serv/buck2",
+                    "--include",
+                    "key1=value1",
+                    "key2=value2",
+                    "--exclude",
+                    "key3=value3",
+                    "key4=value4",
+                ])
+                .unwrap();
+            let query_params = parse_query_params(&context, &args).unwrap();
+
+            assert_eq!(
+                query_params.include_labels,
+                Labels::from_iter(vec![
+                    ("key1".to_string(), "value1".to_string()),
+                    ("key2".to_string(), "value2".to_string()),
+                ])
+            );
+            assert_eq!(
+                query_params.exclude_labels,
+                Labels::from_iter(vec![
+                    ("key3".to_string(), "value3".to_string()),
+                    ("key4".to_string(), "value4".to_string()),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn parse_each_n(context: CliContext) {
+            let args = cp_cmd()
+                .try_get_matches_from(vec!["cp", "serv/buck1", "serv/buck2", "--each-n", "10"])
+                .unwrap();
+            let query_params = parse_query_params(&context, &args).unwrap();
+
+            assert_eq!(query_params.each_n, Some(10));
+        }
+
+        #[rstest]
+        fn parse_each_s(context: CliContext) {
+            let args = cp_cmd()
+                .try_get_matches_from(vec!["cp", "serv/buck1", "serv/buck2", "--each-s", "10"])
+                .unwrap();
+            let query_params = parse_query_params(&context, &args).unwrap();
+
+            assert_eq!(query_params.each_s, Some(10.0));
+        }
+
+        #[rstest]
+        fn parse_limit(context: CliContext) {
+            let args = cp_cmd()
+                .try_get_matches_from(vec!["cp", "serv/buck1", "serv/buck2", "--limit", "100"])
+                .unwrap();
+            let query_params = parse_query_params(&context, &args).unwrap();
+
+            assert_eq!(query_params.limit, Some(100));
+        }
+
+        #[rstest]
+        fn parse_entries_filter(context: CliContext) {
+            let args = cp_cmd()
+                .try_get_matches_from(vec![
+                    "cp",
+                    "serv/buck1",
+                    "serv/buck2",
+                    "--entries",
+                    "entry-1",
+                    "entry-2",
+                ])
+                .unwrap();
+            let query_params = parse_query_params(&context, &args).unwrap();
+
+            assert_eq!(
+                query_params.entry_filter,
+                vec![String::from("entry-1"), String::from("entry-2")]
+            );
+        }
+    }
 }


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?


I've added the `reduct-cli` command to remove records from a bucket. Examples:

```
#remove records via time range
reduct-cli rm alias/bucket --start 2024-01-01T00:00:00Z  --include status=bad

#remove a list of records
reduct-cli rm alias/bucket --time 2024-01-01T00:00:00Z   1000 2000
```

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
