### PR TITLE
RS-661: use T instead of t argument for timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed:
 
 - RS-647: Build binaries for Linux and Macos ARM64, [PR-92](https://github.com/reductstore/reduct-cli/pull/92)
+- RS-661: use `T` instead of `t` argument for timeout, [PR-96](https://github.com/reductstore/reduct-cli/pull/96)
 
 ## [0.6.0] - 2025-03-18
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ fn cli() -> Command {
         .arg(
             Arg::new("timeout")
                 .long("timeout")
-                .short('t')
+                .short('T')
                 .value_name("SECONDS")
                 .help("Timeout for requests")
                 .value_parser(value_parser!(u64))


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The `-t` argument for the timeout conflicts with the `-t` for the API token in the `reduct-cli token create` command. I've renamed the timeout as rarely used. 

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
