### PR TITLE
Add --ext-params flag to copy command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ on:
 
 env:
   REGISTRY_IMAGE: reduct/store
-  MINIMAL_RUST_VERSION: 1.85.0
 
 jobs:
   rust_fmt:
@@ -67,7 +66,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: ${{ env.MINIMAL_RUST_VERSION }}
+          toolchain: ${{ vars.MINIMAL_RUST_VERSION }}
           target: ${{ matrix.target }}
 
       - name: Install gcc
@@ -136,7 +135,7 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: ${{ env.MINIMAL_RUST_VERSION }}
+          toolchain: ${{ vars.MINIMAL_RUST_VERSION }}
       - name: Login
         run: |
           cargo login ${{ secrets.CRATES_IO_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking changes:
+
+- Use `-t` instead of `-T` for the `--time` flag in `reduct-cli rm` command, [PR-108](https://github.com/reductstore/reduct-cli/pull/108)
+
+
+### Added:
+
+- Add `--ext-params` flag to copy command, [PR-108](https://github.com/reductstore/reduct-cli/pull/108)
+
 ## [0.6.1] - 2025-05-07
+
+### Breaking changes:
+
+- RS-661: use `-T` instead of `-t` argument for timeout, [PR-96](https://github.com/reductstore/reduct-cli/pull/96)
 
 ### Changed:
 
 - RS-647: Build binaries for Linux and Macos ARM64, [PR-92](https://github.com/reductstore/reduct-cli/pull/92)
-- RS-661: use `T` instead of `t` argument for timeout, [PR-96](https://github.com/reductstore/reduct-cli/pull/96)
 
 ## [0.6.0] - 2025-03-18
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1298,15 +1298,18 @@ dependencies = [
 
 [[package]]
 name = "reduct-base"
-version = "1.14.3"
+version = "1.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28db8338cbb7d849fbde7ce3b20c803cd6d2e1f2f10882dc39068674cc85433"
+checksum = "00e592a0c330dd1ce8e996f432d3cb46371d943b03fa7ab9e8fb276b0ac0b2f5"
 dependencies = [
+ "bytes",
  "chrono",
  "http",
  "int-enum",
+ "log",
  "serde",
  "serde_json",
+ "thread-id",
  "url",
 ]
 
@@ -1341,9 +1344,9 @@ dependencies = [
 
 [[package]]
 name = "reduct-rs"
-version = "1.14.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6560c9f7ec5091ed048ea651362d3cbfce39651bef6ead408acc5856739fdf04"
+checksum = "95d9451cffe31bfb06267a3cee90f7df773c57273755d28205ca03a345cdacf8"
 dependencies = [
  "async-channel",
  "async-stream",
@@ -1597,6 +1600,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "ryu",
@@ -1811,6 +1815,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
+]
+
+[[package]]
+name = "thread-id"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99043e46c5a15af379c06add30d9c93a6c0e8849de00d244c4a2c417da128d80"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://reduct.store/docs/guides"
 description = "A CLI client for ReductStore written in Rust"
 
 [dependencies]
-reduct-rs = "1.14.0"
+reduct-rs = "1.15.0"
 clap = { version = "4.5.38", features = ["cargo"] }
 dirs = "6.0.0"
 toml = "0.8.22"

--- a/src/cmd/cp.rs
+++ b/src/cmd/cp.rs
@@ -12,7 +12,7 @@ use crate::cmd::cp::b2f::cp_bucket_to_folder;
 use crate::cmd::ALIAS_OR_URL_HELP;
 use crate::context::CliContext;
 use crate::parse::widely_used_args::{
-    make_each_n, make_each_s, make_entries_arg, make_exclude_arg, make_include_arg,
+    make_each_n, make_each_s, make_entries_arg, make_exclude_arg, make_ext_arg, make_include_arg,
     make_strict_arg, make_when_arg,
 };
 use crate::parse::ResourcePathParser;
@@ -80,6 +80,9 @@ pub(crate) fn cp_cmd() -> Command {
                 .help("Export the metadata of the records along with the records in JSON format.\nIf not specified, only the records will be exported.")
                 .required(false)
                 .action(SetTrue)
+        )
+        .arg(
+            make_ext_arg()
         )
 }
 

--- a/src/cmd/cp/b2f.rs
+++ b/src/cmd/cp/b2f.rs
@@ -234,7 +234,7 @@ mod tests {
         #[fixture]
         fn visitor() -> CopyToFolderVisitor {
             CopyToFolderVisitor {
-                dst_folder: tempdir().unwrap().into_path(),
+                dst_folder: tempdir().unwrap().keep(),
                 ext: None,
                 with_meta: false,
             }
@@ -266,7 +266,7 @@ mod tests {
             .await
             .unwrap();
 
-        let path = tempdir().unwrap().into_path();
+        let path = tempdir().unwrap().keep();
         let args = cp_cmd()
             .try_get_matches_from(vec![
                 "cp",

--- a/src/cmd/cp/helpers.rs
+++ b/src/cmd/cp/helpers.rs
@@ -127,6 +127,10 @@ fn build_query(src_bucket: &Bucket, entry: &EntryInfo, query_params: &QueryParam
         query_builder = query_builder.when(when.clone());
     }
 
+    if let Some(ext) = &query_params.ext {
+        query_builder = query_builder.ext(ext.clone());
+    }
+
     query_builder = query_builder.include(query_params.include_labels.clone());
     query_builder = query_builder.exclude(query_params.exclude_labels.clone());
     query_builder = query_builder.strict(query_params.strict);

--- a/src/cmd/replica/create.rs
+++ b/src/cmd/replica/create.rs
@@ -98,7 +98,7 @@ pub(super) async fn create_replica(
 mod tests {
     use super::*;
     use crate::context::tests::{bucket, bucket2, context, replica};
-    use reduct_rs::JsonValue;
+
     use rstest::rstest;
     use serde_json::json;
 

--- a/src/cmd/rm.rs
+++ b/src/cmd/rm.rs
@@ -58,7 +58,7 @@ pub(crate) fn rm_cmd() -> Command {
         .arg(
             Arg::new("time")
                 .long("time")
-                .short('T')
+                .short('t')
                 .value_name("TIMESTAMP")
                 .help("Remove a record with a certain timestamp in ISO format or Unix timestamp in microseconds.")
                 .required(false)

--- a/src/cmd/rm/query_remover.rs
+++ b/src/cmd/rm/query_remover.rs
@@ -90,6 +90,7 @@ mod tests {
             ttl: Default::default(),
             when: None,
             strict: false,
+            ext: None,
         };
 
         let query_remover = QueryRemover::new(bucket, query_params);

--- a/src/io/std.rs
+++ b/src/io/std.rs
@@ -35,35 +35,3 @@ macro_rules! output {
 }
 
 pub(crate) use output;
-
-pub(crate) trait Input {
-    fn read(&self) -> Result<String, anyhow::Error>;
-
-    #[cfg(test)]
-    fn emulate(&self, input: Vec<&'static str>);
-}
-
-pub(crate) struct StdInput;
-
-impl StdInput {
-    pub(crate) fn new() -> Self {
-        StdInput {}
-    }
-}
-
-impl Input for StdInput {
-    fn read(&self) -> Result<String, anyhow::Error> {
-        let mut input = String::new();
-        std::io::stdin().read_line(&mut input)?;
-        Ok(input.trim().to_string())
-    }
-
-    #[cfg(test)]
-    fn emulate(&self, _input: Vec<&'static str>) {}
-}
-
-macro_rules! input {
-    ($ctx:expr) => {
-        $ctx.stdin().read()
-    };
-}

--- a/src/parse/helpers.rs
+++ b/src/parse/helpers.rs
@@ -10,7 +10,6 @@ use clap::parser::MatchesError;
 use clap::ArgMatches;
 use reduct_rs::{Bucket, EntryInfo, Labels};
 use serde_json::Value;
-use std::str::Matches;
 use std::time::Duration;
 
 pub(crate) async fn fetch_and_filter_entries(

--- a/src/parse/helpers.rs
+++ b/src/parse/helpers.rs
@@ -6,9 +6,11 @@
 use crate::context::CliContext;
 use crate::parse::widely_used_args::parse_label_args;
 use chrono::DateTime;
+use clap::parser::MatchesError;
 use clap::ArgMatches;
 use reduct_rs::{Bucket, EntryInfo, Labels};
 use serde_json::Value;
+use std::str::Matches;
 use std::time::Duration;
 
 pub(crate) async fn fetch_and_filter_entries(
@@ -69,6 +71,7 @@ pub(crate) struct QueryParams {
     pub ttl: Duration,
     pub when: Option<Value>,
     pub strict: bool,
+    pub ext: Option<Value>,
 }
 
 impl Default for QueryParams {
@@ -86,6 +89,7 @@ impl Default for QueryParams {
             ttl: Duration::from_secs(60),
             when: None,
             strict: false,
+            ext: None,
         }
     }
 }
@@ -102,6 +106,11 @@ pub(crate) fn parse_query_params(
     let each_s = args.get_one::<f64>("each-s").map(|s| *s);
     let when = args.get_one::<String>("when").map(|s| s.to_string());
     let strict = args.get_one::<bool>("strict").unwrap_or(&false);
+    let ext_params = match args.try_get_one::<String>("ext-params") {
+        Ok(s) => s.cloned(),
+        Err(MatchesError::UnknownArgument { .. }) => None, // ext-params is optional for some commands
+        Err(err) => return Err(anyhow::anyhow!("Failed to parse ext-params: {}", err)),
+    };
 
     // arguments aren't used in all cases
     let limit = args
@@ -127,6 +136,17 @@ pub(crate) fn parse_query_params(
         None => None,
     };
 
+    let ext_json = match ext_params {
+        Some(params) => {
+            let ext_json = match serde_json::from_str(&params) {
+                Ok(json) => json,
+                Err(err) => return Err(anyhow::anyhow!("Failed to parse ext-params: {}", err)),
+            };
+            Some(Value::Object(ext_json))
+        }
+        None => None,
+    };
+
     Ok(QueryParams {
         start,
         stop,
@@ -140,6 +160,7 @@ pub(crate) fn parse_query_params(
         ttl: ctx.timeout() * ctx.parallel() as u32,
         when: json_when,
         strict: *strict,
+        ext: ext_json,
     })
 }
 

--- a/src/parse/widely_used_args.rs
+++ b/src/parse/widely_used_args.rs
@@ -76,6 +76,15 @@ pub(crate) fn make_strict_arg() -> Arg {
         .required(false)
 }
 
+pub(crate) fn make_ext_arg() -> Arg {
+    Arg::new("ext-params")
+        .long("ext-params")
+        .short('X')
+        .value_name("EXT_PARAMETERS")
+        .help("Pass additional parameters to extensions in JSON format.")
+        .required(false)
+}
+
 pub(crate) fn parse_label(label: &str) -> anyhow::Result<(String, String)> {
     let mut label = label.splitn(2, '=');
     Ok((


### PR DESCRIPTION
Closes #102

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

The PR adds the `--ext-params` flag to the `reduct -cli  cp`  command  to use extension during copy operations.
Additionally. renamed -T to -t shortcut for the --time argument of the remove command to avoid conflict with the -T (timeout). 

### Related issues

#102 

### Does this PR introduce a breaking change?

Yes

### Other information:
