### PR TITLE
Remove include/exclude options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking changes:
+
+- Remove include/exclude options from `reduct-cli cp` and `reduct-cli replica` commands, [PR-122](https://github.com/reductstore/reduct-cli/pull/122)
+
 ## [0.7.0] - 2025-06-11
 
 ### Breaking changes:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,7 +360,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1309,12 +1309,13 @@ dependencies = [
 
 [[package]]
 name = "reduct-base"
-version = "1.15.5"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43fe6b776c68f167cb57cc5bccbc721f8bc0e7d8e40effbff88777299f10629f"
+checksum = "bf3d9c57357d075dc6d19007e1c99c4b726b224d17e12d6f38b8fc91eff287e3"
 dependencies = [
  "bytes",
  "chrono",
+ "futures",
  "http",
  "int-enum",
  "log",
@@ -1355,9 +1356,9 @@ dependencies = [
 
 [[package]]
 name = "reduct-rs"
-version = "1.15.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0010333f89a4a2b900c8b28c8e0eb36fda06113df3acbc0f7bed3c4e2914fae1"
+checksum = "c13226b10b6306c48a1ca7b920ba81195d21bb56bfa4d8465bec30d513233c68"
 dependencies = [
  "async-channel",
  "async-stream",
@@ -1607,9 +1608,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
  "indexmap",
  "itoa",

--- a/src/cmd/cp.rs
+++ b/src/cmd/cp.rs
@@ -12,7 +12,7 @@ use crate::cmd::cp::b2f::cp_bucket_to_folder;
 use crate::cmd::ALIAS_OR_URL_HELP;
 use crate::context::CliContext;
 use crate::parse::widely_used_args::{
-    make_each_n, make_each_s, make_entries_arg, make_exclude_arg, make_ext_arg, make_include_arg,
+    make_each_n, make_each_s, make_entries_arg, make_ext_arg,
     make_strict_arg, make_when_arg,
 };
 use crate::parse::ResourcePathParser;
@@ -49,8 +49,6 @@ pub(crate) fn cp_cmd() -> Command {
                 .help("Export records with timestamps newer than this time point in ISO format or Unix timestamp in microseconds.\nIf not specified, the export will end at the last record in an entry.")
                 .required(false)
         )
-        .arg(make_include_arg())
-        .arg(make_exclude_arg())
         .arg(make_entries_arg())
         .arg(make_when_arg())
         .arg(make_strict_arg())

--- a/src/cmd/cp.rs
+++ b/src/cmd/cp.rs
@@ -12,8 +12,7 @@ use crate::cmd::cp::b2f::cp_bucket_to_folder;
 use crate::cmd::ALIAS_OR_URL_HELP;
 use crate::context::CliContext;
 use crate::parse::widely_used_args::{
-    make_each_n, make_each_s, make_entries_arg, make_ext_arg,
-    make_strict_arg, make_when_arg,
+    make_each_n, make_each_s, make_entries_arg, make_ext_arg, make_strict_arg, make_when_arg,
 };
 use crate::parse::ResourcePathParser;
 use clap::ArgAction::SetTrue;

--- a/src/cmd/cp/helpers.rs
+++ b/src/cmd/cp/helpers.rs
@@ -130,9 +130,7 @@ fn build_query(src_bucket: &Bucket, entry: &EntryInfo, query_params: &QueryParam
     if let Some(ext) = &query_params.ext {
         query_builder = query_builder.ext(ext.clone());
     }
-
-    query_builder = query_builder.include(query_params.include_labels.clone());
-    query_builder = query_builder.exclude(query_params.exclude_labels.clone());
+    
     query_builder = query_builder.strict(query_params.strict);
 
     if let Some(limit) = query_params.limit {
@@ -453,63 +451,6 @@ mod tests {
 
             let params = QueryParams {
                 limit: Some(1),
-                ..Default::default()
-            };
-
-            start_loading(src_bucket, params, visitor).await.unwrap();
-        }
-
-        #[rstest]
-        #[tokio::test]
-        async fn test_downloading_include(#[future] src_bucket: Bucket, mut visitor: MockVisitor) {
-            let src_bucket = src_bucket.await;
-            visitor
-                .expect_visit()
-                .times(1)
-                .with(eq("entry-1"), always())
-                .return_const(Ok(()));
-
-            src_bucket
-                .write_record("entry-1")
-                .data(Bytes::from_static(b"rec-3"))
-                .add_label("key1", "value1")
-                .send()
-                .await
-                .unwrap();
-
-            let params = QueryParams {
-                include_labels: Labels::from_iter(vec![("key1".to_string(), "value1".to_string())]),
-                ..Default::default()
-            };
-
-            start_loading(src_bucket, params, visitor).await.unwrap();
-        }
-
-        #[rstest]
-        #[tokio::test]
-        async fn test_downloading_exclude(#[future] src_bucket: Bucket, mut visitor: MockVisitor) {
-            let src_bucket = src_bucket.await;
-            visitor
-                .expect_visit()
-                .times(1)
-                .with(eq("entry-1"), always())
-                .return_const(Ok(()));
-            visitor
-                .expect_visit()
-                .times(1)
-                .with(eq("entry-2"), always())
-                .return_const(Ok(()));
-
-            src_bucket
-                .write_record("entry-1")
-                .data(Bytes::from_static(b"rec-3"))
-                .add_label("key1", "value1")
-                .send()
-                .await
-                .unwrap();
-
-            let params = QueryParams {
-                exclude_labels: Labels::from_iter(vec![("key1".to_string(), "value1".to_string())]),
                 ..Default::default()
             };
 

--- a/src/cmd/cp/helpers.rs
+++ b/src/cmd/cp/helpers.rs
@@ -130,7 +130,7 @@ fn build_query(src_bucket: &Bucket, entry: &EntryInfo, query_params: &QueryParam
     if let Some(ext) = &query_params.ext {
         query_builder = query_builder.ext(ext.clone());
     }
-    
+
     query_builder = query_builder.strict(query_params.strict);
 
     if let Some(limit) = query_params.limit {

--- a/src/cmd/replica/create.rs
+++ b/src/cmd/replica/create.rs
@@ -5,9 +5,7 @@
 
 use crate::cmd::RESOURCE_PATH_HELP;
 use crate::io::reduct::{build_client, parse_url_and_token};
-use crate::parse::widely_used_args::{
-    make_each_n, make_each_s, make_entries_arg, make_when_arg,
-};
+use crate::parse::widely_used_args::{make_each_n, make_each_s, make_entries_arg, make_when_arg};
 use crate::parse::ResourcePathParser;
 use clap::{Arg, Command};
 use reduct_rs::Labels;
@@ -55,7 +53,6 @@ pub(super) async fn create_replica(
         .unwrap_or_default()
         .map(|s| s.to_string())
         .collect::<Vec<String>>();
-
 
     let each_n = args.get_one::<u64>("each-n");
     let each_s = args.get_one::<f64>("each-s");

--- a/src/cmd/replica/create.rs
+++ b/src/cmd/replica/create.rs
@@ -131,10 +131,6 @@ mod tests {
         assert_eq!(replica.settings.dst_bucket, bucket2);
         assert_eq!(replica.settings.dst_host, "http://localhost:8383/");
         assert_eq!(replica.settings.dst_token, "***");
-        assert_eq!(
-            replica.settings.include,
-            Labels::from_iter(vec![("key1".to_string(), "value2".to_string())])
-        );
         assert_eq!(replica.settings.each_n, Some(10));
         assert_eq!(replica.settings.each_s, Some(0.5));
         assert_eq!(

--- a/src/cmd/replica/create.rs
+++ b/src/cmd/replica/create.rs
@@ -114,10 +114,6 @@ mod tests {
             format!("local/{}", test_replica).as_str(),
             &bucket,
             format!("local/{}", bucket2).as_str(),
-            "--include",
-            "key1=value2",
-            "--exclude",
-            "key2=value3",
             "--entries",
             "entry1",
             "entry2",
@@ -138,14 +134,6 @@ mod tests {
         assert_eq!(
             replica.settings.include,
             Labels::from_iter(vec![("key1".to_string(), "value2".to_string())])
-        );
-        assert_eq!(
-            replica.settings.exclude,
-            Labels::from_iter(vec![("key2".to_string(), "value3".to_string())])
-        );
-        assert_eq!(
-            replica.settings.entries,
-            vec!["entry1".to_string(), "entry2".to_string()]
         );
         assert_eq!(replica.settings.each_n, Some(10));
         assert_eq!(replica.settings.each_s, Some(0.5));

--- a/src/cmd/replica/create.rs
+++ b/src/cmd/replica/create.rs
@@ -6,8 +6,7 @@
 use crate::cmd::RESOURCE_PATH_HELP;
 use crate::io::reduct::{build_client, parse_url_and_token};
 use crate::parse::widely_used_args::{
-    make_each_n, make_each_s, make_entries_arg, make_exclude_arg, make_include_arg, make_when_arg,
-    parse_label_args,
+    make_each_n, make_each_s, make_entries_arg, make_when_arg,
 };
 use crate::parse::ResourcePathParser;
 use clap::{Arg, Command};
@@ -34,8 +33,6 @@ pub(super) fn create_replica_cmd() -> Command {
                 .value_parser(ResourcePathParser::new())
                 .required(true),
         )
-        .arg(make_include_arg())
-        .arg(make_exclude_arg())
         .arg(make_entries_arg())
         .arg(make_each_n())
         .arg(make_each_s())
@@ -59,8 +56,7 @@ pub(super) async fn create_replica(
         .map(|s| s.to_string())
         .collect::<Vec<String>>();
 
-    let include = parse_label_args(args.get_many::<String>("include"))?.unwrap_or_default();
-    let exclude = parse_label_args(args.get_many::<String>("exclude"))?.unwrap_or_default();
+
     let each_n = args.get_one::<u64>("each-n");
     let each_s = args.get_one::<f64>("each-s");
     let when = args.get_one::<String>("when");
@@ -74,8 +70,6 @@ pub(super) async fn create_replica(
         .dst_bucket(dest_bucket_name)
         .dst_host(dest_url.as_str())
         .dst_token(&token)
-        .include(Labels::from_iter(include))
-        .exclude(Labels::from_iter(exclude))
         .entries(entries_filter);
 
     if let Some(when) = when {

--- a/src/cmd/replica/update.rs
+++ b/src/cmd/replica/update.rs
@@ -152,11 +152,6 @@ mod tests {
         assert_eq!(replica.settings.dst_bucket, bucket2);
         assert_eq!(replica.settings.dst_host, "http://localhost:8383/");
         assert_eq!(replica.settings.dst_token, "***");
-        assert_eq!(
-            replica.settings.include,
-            Labels::from_iter(vec![("key1".to_string(), "value2".to_string())])
-        );
-        assert!(replica.settings.exclude.is_empty());
         assert!(replica.settings.entries.is_empty());
         assert_eq!(replica.settings.each_n, Some(10));
         assert_eq!(replica.settings.each_s, Some(0.5));

--- a/src/cmd/replica/update.rs
+++ b/src/cmd/replica/update.rs
@@ -7,8 +7,7 @@ use crate::cmd::RESOURCE_PATH_HELP;
 use crate::context::CliContext;
 use crate::io::reduct::{build_client, parse_url_and_token};
 use crate::parse::widely_used_args::{
-    make_each_n, make_each_s, make_entries_arg, make_exclude_arg, make_include_arg, make_when_arg,
-    parse_label_args,
+    make_each_n, make_each_s, make_entries_arg, make_when_arg,
 };
 use crate::parse::ResourcePathParser;
 
@@ -38,8 +37,6 @@ pub(super) fn update_replica_cmd() -> Command {
                 .help("Source bucket on the replicated instance")
                 .required(false),
         )
-        .arg(make_include_arg())
-        .arg(make_exclude_arg())
         .arg(make_entries_arg())
         .arg(make_each_n())
         .arg(make_each_s())
@@ -79,9 +76,7 @@ fn update_replication_settings(
     let entries_filter = args
         .get_many::<String>("entries")
         .map(|s| s.map(|s| s.to_string()).collect::<Vec<String>>());
-
-    let include = parse_label_args(args.get_many::<String>("include"))?;
-    let exclude = parse_label_args(args.get_many::<String>("exclude"))?;
+    
     let each_n = args.get_one::<u64>("each-n");
     let each_s = args.get_one::<f64>("each-s");
     let when = args.get_one::<String>("when");
@@ -93,14 +88,6 @@ fn update_replication_settings(
 
     if let Some(source_bucket_name) = source_bucket_name {
         current_settings.src_bucket = source_bucket_name.clone();
-    }
-
-    if let Some(include) = include {
-        current_settings.include = include;
-    }
-
-    if let Some(exclude) = exclude {
-        current_settings.exclude = exclude;
     }
 
     if let Some(entries_filter) = entries_filter {

--- a/src/cmd/replica/update.rs
+++ b/src/cmd/replica/update.rs
@@ -136,8 +136,6 @@ mod tests {
                 "update",
                 format!("local/{}", test_replica).as_str(),
                 format!("local/{}", &bucket2).as_str(),
-                "--include",
-                "key1=value2",
                 "--each-n",
                 "10",
                 "--each-s",

--- a/src/cmd/replica/update.rs
+++ b/src/cmd/replica/update.rs
@@ -6,9 +6,7 @@
 use crate::cmd::RESOURCE_PATH_HELP;
 use crate::context::CliContext;
 use crate::io::reduct::{build_client, parse_url_and_token};
-use crate::parse::widely_used_args::{
-    make_each_n, make_each_s, make_entries_arg, make_when_arg,
-};
+use crate::parse::widely_used_args::{make_each_n, make_each_s, make_entries_arg, make_when_arg};
 use crate::parse::ResourcePathParser;
 
 use clap::{Arg, ArgMatches, Command};
@@ -76,7 +74,7 @@ fn update_replication_settings(
     let entries_filter = args
         .get_many::<String>("entries")
         .map(|s| s.map(|s| s.to_string()).collect::<Vec<String>>());
-    
+
     let each_n = args.get_one::<u64>("each-n");
     let each_s = args.get_one::<f64>("each-s");
     let when = args.get_one::<String>("when");

--- a/src/cmd/rm.rs
+++ b/src/cmd/rm.rs
@@ -12,7 +12,7 @@ use crate::cmd::ALIAS_OR_URL_HELP;
 use crate::context::CliContext;
 use crate::io::reduct::build_client;
 use crate::parse::widely_used_args::{
-    make_each_n, make_each_s, make_entries_arg, make_exclude_arg, make_include_arg,
+    make_each_n, make_each_s, make_entries_arg,
     make_strict_arg, make_when_arg,
 };
 use crate::parse::{fetch_and_filter_entries, parse_query_params, QueryParams, ResourcePathParser};
@@ -48,8 +48,6 @@ pub(crate) fn rm_cmd() -> Command {
                 .help("Remove records with timestamps newer than this time point in ISO format or Unix timestamp in microseconds.\nIf not specified, the export will end at the last record in an entry.")
                 .required(false)
         )
-        .arg(make_include_arg())
-        .arg(make_exclude_arg())
         .arg(make_entries_arg())
         .arg(make_each_n())
         .arg(make_each_s())

--- a/src/cmd/rm.rs
+++ b/src/cmd/rm.rs
@@ -12,8 +12,7 @@ use crate::cmd::ALIAS_OR_URL_HELP;
 use crate::context::CliContext;
 use crate::io::reduct::build_client;
 use crate::parse::widely_used_args::{
-    make_each_n, make_each_s, make_entries_arg,
-    make_strict_arg, make_when_arg,
+    make_each_n, make_each_s, make_entries_arg, make_strict_arg, make_when_arg,
 };
 use crate::parse::{fetch_and_filter_entries, parse_query_params, QueryParams, ResourcePathParser};
 use async_trait::async_trait;

--- a/src/cmd/rm/query_remover.rs
+++ b/src/cmd/rm/query_remover.rs
@@ -49,9 +49,6 @@ impl QueryRemover {
             query_builder = query_builder.each_s(each_s);
         }
 
-        query_builder = query_builder.include(self.query_params.include_labels.clone());
-        query_builder = query_builder.exclude(self.query_params.exclude_labels.clone());
-
         if let Some(when) = &self.query_params.when {
             query_builder = query_builder.when(when.clone());
         }
@@ -85,8 +82,6 @@ mod tests {
             limit: None,
             entry_filter: vec![],
             parallel: 0,
-            include_labels: HashMap::new(),
-            exclude_labels: HashMap::new(),
             ttl: Default::default(),
             when: None,
             strict: false,

--- a/src/parse/helpers.rs
+++ b/src/parse/helpers.rs
@@ -212,7 +212,6 @@ mod test {
             assert_eq!(query_params.start, Some(1672531200000000));
             assert_eq!(query_params.stop, Some(1672617600000000));
         }
-        
 
         #[rstest]
         fn parse_each_n(context: CliContext) {

--- a/src/parse/helpers.rs
+++ b/src/parse/helpers.rs
@@ -4,7 +4,6 @@
 //    file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use crate::context::CliContext;
-use crate::parse::widely_used_args::parse_label_args;
 use chrono::DateTime;
 use clap::parser::MatchesError;
 use clap::ArgMatches;
@@ -60,8 +59,6 @@ pub(crate) fn parse_time(time_str: Option<&String>) -> anyhow::Result<Option<u64
 pub(crate) struct QueryParams {
     pub start: Option<u64>,
     pub stop: Option<u64>,
-    pub include_labels: Labels,
-    pub exclude_labels: Labels,
     pub each_n: Option<u64>,
     pub each_s: Option<f64>,
     pub limit: Option<u64>,
@@ -78,8 +75,6 @@ impl Default for QueryParams {
         Self {
             start: None,
             stop: None,
-            include_labels: Labels::new(),
-            exclude_labels: Labels::new(),
             each_n: None,
             each_s: None,
             limit: None,
@@ -99,8 +94,6 @@ pub(crate) fn parse_query_params(
 ) -> anyhow::Result<QueryParams> {
     let start = parse_time(args.get_one::<String>("start"))?;
     let stop = parse_time(args.get_one::<String>("stop"))?;
-    let include_labels = parse_label_args(args.get_many::<String>("include"))?.unwrap_or_default();
-    let exclude_labels = parse_label_args(args.get_many::<String>("exclude"))?.unwrap_or_default();
     let each_n = args.get_one::<u64>("each-n").map(|n| *n);
     let each_s = args.get_one::<f64>("each-s").map(|s| *s);
     let when = args.get_one::<String>("when").map(|s| s.to_string());
@@ -149,8 +142,6 @@ pub(crate) fn parse_query_params(
     Ok(QueryParams {
         start,
         stop,
-        include_labels,
-        exclude_labels,
         each_n,
         each_s,
         limit,
@@ -221,39 +212,7 @@ mod test {
             assert_eq!(query_params.start, Some(1672531200000000));
             assert_eq!(query_params.stop, Some(1672617600000000));
         }
-
-        #[rstest]
-        fn parse_include_exclude(context: CliContext) {
-            let args = cp_cmd()
-                .try_get_matches_from(vec![
-                    "cp",
-                    "serv/buck1",
-                    "serv/buck2",
-                    "--include",
-                    "key1=value1",
-                    "key2=value2",
-                    "--exclude",
-                    "key3=value3",
-                    "key4=value4",
-                ])
-                .unwrap();
-            let query_params = parse_query_params(&context, &args).unwrap();
-
-            assert_eq!(
-                query_params.include_labels,
-                Labels::from_iter(vec![
-                    ("key1".to_string(), "value1".to_string()),
-                    ("key2".to_string(), "value2".to_string()),
-                ])
-            );
-            assert_eq!(
-                query_params.exclude_labels,
-                Labels::from_iter(vec![
-                    ("key3".to_string(), "value3".to_string()),
-                    ("key4".to_string(), "value4".to_string()),
-                ])
-            );
-        }
+        
 
         #[rstest]
         fn parse_each_n(context: CliContext) {

--- a/src/parse/widely_used_args.rs
+++ b/src/parse/widely_used_args.rs
@@ -8,31 +8,11 @@ use clap::ArgAction::SetTrue;
 use clap::{value_parser, Arg};
 use reduct_rs::Labels;
 
-pub(crate) fn make_include_arg() -> Arg {
-    Arg::new("include")
-        .long("include")
-        .short('I')
-        .value_name("KEY=VALUE")
-        .help("Deprecated. Use --when instead.\nThese records which have this key-value pair will be requested.\nThe format is key=value. This option can be used multiple times to include multiple key-value pairs.")
-        .num_args(0..)
-        .required(false)
-}
-
-pub(crate) fn make_exclude_arg() -> Arg {
-    Arg::new("exclude")
-        .long("exclude")
-        .short('E')
-        .value_name("KEY=VALUE")
-        .help("Deprecated. Use --when instead.\nThese records which have this key-value pair will be excluded.\nThe format is key=value. This option can be used multiple times to exclude multiple key-value pairs.")
-        .num_args(0..)
-        .required(false)
-}
-
 pub(crate) fn make_each_n() -> Arg {
     Arg::new("each-n")
         .long("each-n")
         .short('N')
-        .help("Export every nth record.\nIf not specified, all records will be requested.")
+        .help("(DEPRECATED) Export every nth record.\nIf not specified, all records will be requested.")
         .value_name("NUMBER")
         .value_parser(value_parser!(u64))
         .required(false)
@@ -42,7 +22,7 @@ pub(crate) fn make_each_s() -> Arg {
     Arg::new("each-s")
         .long("each-s")
         .short('S')
-        .help("Export a record every n seconds.\nIf not specified, all records will be requested.")
+        .help("(DEPRECATED) Export a record every n seconds.\nIf not specified, all records will be requested.")
         .value_name("NUMBER")
         .value_parser(value_parser!(f64))
         .required(false)
@@ -97,18 +77,4 @@ pub(crate) fn parse_label(label: &str) -> anyhow::Result<(String, String)> {
             .ok_or(anyhow::anyhow!("Invalid label"))?
             .to_string(),
     ))
-}
-
-pub(crate) fn parse_label_args(args: Option<ValuesRef<String>>) -> anyhow::Result<Option<Labels>> {
-    let mut result: Option<Labels> = None;
-    if let Some(include_args) = args {
-        let mut labels = Labels::new();
-        for arg in include_args {
-            let (key, value) = parse_label(&arg)?;
-            let _ = labels.insert(key, value);
-        }
-
-        result = Some(labels);
-    }
-    Ok(result)
 }


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Breaking changes

### What was changed?

The `include` and `exclude` query and replication parameters have been flagged as replicated since v1.13.  The PR removes these options, and users should use the `--when` flag more flexibly.

### Related issues

https://github.com/reductstore/reduct-rs/pull/41

### Does this PR introduce a breaking change?

Yes

### Other information:
