### PR TITLE
Add attempts to reduct-cli cp command to recover after errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add attempts to `reduct-cli cp` command to recover after errors, [PR-132](https://github.com/reductstore/reduct-cli/pull/132)
 
 ## [0.8.0] - 2025-08-31
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1356,9 +1356,9 @@ dependencies = [
 
 [[package]]
 name = "reduct-rs"
-version = "1.16.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13226b10b6306c48a1ca7b920ba81195d21bb56bfa4d8465bec30d513233c68"
+checksum = "b69a53947810981cbafda192aaf6f73e7b64467ddc068f11dfe07764fc6c6b1d"
 dependencies = [
  "async-channel",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://reduct.store/docs/guides"
 description = "A CLI client for ReductStore written in Rust"
 
 [dependencies]
-reduct-rs = "1.15.2"
+reduct-rs = { version = "1.16.1" }
 clap = { version = "4.5.41", features = ["cargo"] }
 dirs = "6.0.0"
 toml = "0.9.2"


### PR DESCRIPTION
Closes #127

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature 

### What was changed?

The PR uses the latest reduct-rs library with better error handling and introduces retries in the download cycle. Instead of crashing, the CLI now tries to continue downloading from the last downloaded record. It also takes the account --limit flag into account when.

### Related issues

#127  https://github.com/reductstore/reduct-rs/pull/44

### Does this PR introduce a breaking change?

No

### Other information:
