### PR TITLE
Ignore 401,403 and 503 errors during license check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed
+
+- Ignore 401,403 and 503 errors during license check, [PR-146](https://github.com/reductstore/reduct-cli/pull/146)
+
 ## [0.9.1] - 2025-10-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,11 @@ RS-633: Link runtime libraries statically, [PR-85](https://github.com/reductstor
 
 - Moved from https://github.com/reductstore/reductstore
 
-[Unreleased]: https://github.com/reductstore/reduct-cli/compare/0.8.0...HEAD
+[Unreleased]: https://github.com/reductstore/reduct-cli/compare/0.9.1...HEAD
+
+[0.9.1]: https://github.com/reductstore/reduct-cli/compare/v0.9.0...v0.9.1
+
+[0.9.0]: https://github.com/reductstore/reduct-cli/compare/v0.8.0...v0.9.0
 
 [0.8.0]: https://github.com/reductstore/reduct-cli/compare/v0.7.0...v0.8.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1331,7 +1331,7 @@ dependencies = [
 
 [[package]]
 name = "reduct-cli"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src/io/reduct.rs
+++ b/src/io/reduct.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 ReductStore
+// Copyright 2023-2025 ReductStore
 // This Source Code Form is subject to the terms of the Mozilla Public
 //    License, v. 2.0. If a copy of the MPL was not distributed with this
 //    file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -7,7 +7,7 @@ use crate::config::find_alias;
 use crate::context::CliContext;
 use anyhow::anyhow;
 use colored::Colorize;
-use reduct_rs::{ErrorCode, ReductClient, ReductError};
+use reduct_rs::{ErrorCode, ReductClient, ReductError, ServerInfo};
 use url::Url;
 
 /// Build a ReductStore client from an alias or URL
@@ -27,8 +27,8 @@ pub(crate) async fn build_client(
         .timeout(ctx.timeout())
         .try_build()?;
 
-    let status = match client.server_info().await {
-        Ok(status) => status,
+    match client.server_info().await {
+        Ok(status) => check_usage(url, status),
         Err(ReductError {
             status: ErrorCode::ConnectionError,
             message,
@@ -52,9 +52,20 @@ pub(crate) async fn build_client(
 
             return Err(ReductError::new(ErrorCode::ConnectionError, &message).into());
         }
+        Err(err)
+            if err.status() == ErrorCode::ServiceUnavailable
+                || err.status() == ErrorCode::Unauthorized
+                || err.status() == ErrorCode::Forbidden =>
+        {
+            /* Ignore service unavailable errors for status checks. We still need to use the cli for health checks*/
+        }
         Err(err) => return Err(err.into()),
     };
 
+    Ok(client)
+}
+
+fn check_usage(url: Url, status: ServerInfo) {
     if let Some(license) = status.license {
         if license.expiry_date < chrono::Utc::now() {
             eprintln!(
@@ -84,8 +95,6 @@ pub(crate) async fn build_client(
             );
         }
     }
-
-    Ok(client)
 }
 
 /// Parse an alias or URL into a URL and a token

--- a/src/io/reduct.rs
+++ b/src/io/reduct.rs
@@ -137,14 +137,8 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn test_build_client_with_url(context: CliContext) {
-        let err = build_client(&context, "http://localhost:8383")
-            .await
-            .err()
-            .unwrap();
-        assert_eq!(
-            err.to_string(),
-            "[Unauthorized] No bearer token in request header"
-        );
+        let result = build_client(&context, "http://localhost:8383").await;
+        assert!(result.is_ok());
     }
 
     #[rstest]

--- a/src/parse/widely_used_args.rs
+++ b/src/parse/widely_used_args.rs
@@ -62,17 +62,3 @@ pub(crate) fn make_ext_arg() -> Arg {
         .help("Pass additional parameters to extensions in JSON format.")
         .required(false)
 }
-
-pub(crate) fn parse_label(label: &str) -> anyhow::Result<(String, String)> {
-    let mut label = label.splitn(2, '=');
-    Ok((
-        label
-            .next()
-            .ok_or(anyhow::anyhow!("Invalid label"))?
-            .to_string(),
-        label
-            .next()
-            .ok_or(anyhow::anyhow!("Invalid label"))?
-            .to_string(),
-    ))
-}


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The PR fixes the usage check before each command, bypassing the authentication and service unavailable errors.
This means that commands such as `reduct-cli status alive` can work without authentication and check an instance before initializing the storage. 

### Related issues

https://github.com/reductstore/reductstore/pull/969

### Does this PR introduce a breaking change?

No

### Other information:
