### PR TITLE
Add replica mode commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add batching in reduct-cli for cp command, [PR-148](https://github.com/reductstore/reduct-cli/pull/148)
 - Show bucket status and update copy/removal handling, [PR-167](https://github.com/reductstore/reduct-cli/pull/167)
+- Add replica mode commands and mode-aware outputs, [PR-168](https://github.com/reductstore/reduct-cli/pull/168)
 
 ## 0.9.4 - 2025-12-17
 

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -8,6 +8,7 @@ pub(crate) mod cp;
 pub(crate) mod replica;
 pub(crate) mod rm;
 pub(crate) mod server;
+pub(crate) mod table;
 pub(crate) mod token;
 
 const ALIAS_OR_URL_HELP: &str =

--- a/src/cmd/replica.rs
+++ b/src/cmd/replica.rs
@@ -6,11 +6,16 @@
 mod create;
 mod helpers;
 mod ls;
+mod mode;
 mod rm;
 mod show;
 mod update;
 
 use crate::cmd::replica::ls::{ls_replica, ls_replica_cmd};
+use crate::cmd::replica::mode::{
+    disable_replica_cmd, disable_replica_handler, enable_replica_cmd, enable_replica_handler,
+    pause_replica_cmd, pause_replica_handler,
+};
 use crate::cmd::replica::rm::{rm_replica_cmd, rm_replica_handler};
 use crate::cmd::replica::show::{show_replica_cmd, show_replica_handler};
 use crate::cmd::replica::update::{update_replica_cmd, update_replica_handler};
@@ -25,6 +30,9 @@ pub(crate) fn replication_cmd() -> Command {
         .subcommand(update_replica_cmd())
         .subcommand(ls_replica_cmd())
         .subcommand(show_replica_cmd())
+        .subcommand(enable_replica_cmd())
+        .subcommand(disable_replica_cmd())
+        .subcommand(pause_replica_cmd())
         .subcommand(rm_replica_cmd())
 }
 
@@ -37,6 +45,9 @@ pub(crate) async fn replication_handler(
         Some(("update", args)) => update_replica_handler(_ctx, args).await?,
         Some(("ls", args)) => ls_replica(_ctx, args).await?,
         Some(("show", args)) => show_replica_handler(_ctx, args).await?,
+        Some(("enable", args)) => enable_replica_handler(_ctx, args).await?,
+        Some(("disable", args)) => disable_replica_handler(_ctx, args).await?,
+        Some(("pause", args)) => pause_replica_handler(_ctx, args).await?,
         Some(("rm", args)) => rm_replica_handler(_ctx, args).await?,
         _ => (),
     }

--- a/src/cmd/replica.rs
+++ b/src/cmd/replica.rs
@@ -1,9 +1,10 @@
-// Copyright 2024 ReductStore
+// Copyright 2024-2026 ReductStore
 // This Source Code Form is subject to the terms of the Mozilla Public
 //    License, v. 2.0. If a copy of the MPL was not distributed with this
 //    file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 mod create;
+mod helpers;
 mod ls;
 mod rm;
 mod show;

--- a/src/cmd/replica/helpers.rs
+++ b/src/cmd/replica/helpers.rs
@@ -1,0 +1,14 @@
+// Copyright 2026 ReductStore
+// This Source Code Form is subject to the terms of the Mozilla Public
+//    License, v. 2.0. If a copy of the MPL was not distributed with this
+//    file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use reduct_rs::ReplicationMode;
+
+pub(crate) fn print_replication_mode(mode: ReplicationMode) -> String {
+    match mode {
+        ReplicationMode::Enabled => "Enabled".to_string(),
+        ReplicationMode::Paused => "Paused".to_string(),
+        ReplicationMode::Disabled => "Disabled".to_string(),
+    }
+}

--- a/src/cmd/replica/ls.rs
+++ b/src/cmd/replica/ls.rs
@@ -1,13 +1,13 @@
-// Copyright 2024 ReductStore
+// Copyright 2024-2026 ReductStore
 // This Source Code Form is subject to the terms of the Mozilla Public
 //    License, v. 2.0. If a copy of the MPL was not distributed with this
 //    file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::cmd::replica::helpers::print_replication_mode;
 use crate::cmd::ALIAS_OR_URL_HELP;
 use crate::io::std::output;
 use clap::ArgAction::SetTrue;
 use clap::{Arg, Command};
-
 use reduct_rs::ReplicationInfo;
 use tabled::{settings::Style, Table, Tabled};
 
@@ -35,6 +35,8 @@ struct ReplicationTable {
     name: String,
     #[tabled(rename = "State")]
     state: String,
+    #[tabled(rename = "Mode")]
+    mode: String,
     #[tabled(rename = "Pending Records")]
     pending_records: u64,
     #[tabled(rename = "Provisioned")]
@@ -50,6 +52,7 @@ impl From<ReplicationInfo> for ReplicationTable {
             } else {
                 "Inactive".to_string()
             },
+            mode: print_replication_mode(replication.mode),
             pending_records: replication.pending_records,
             is_provisioned: replication.is_provisioned,
         }
@@ -145,7 +148,7 @@ mod tests {
         assert_eq!(
             context.stdout().history(),
             vec![
-                "| Name         | State  | Pending Records | Provisioned |\n|--------------|--------|-----------------|-------------|\n| test_replica | Active | 0               | false       |"
+                "| Name         | State  | Mode    | Pending Records | Provisioned |\n|--------------|--------|---------|-----------------|-------------|\n| test_replica | Active | Enabled | 0               | false       |"
             ]
         );
     }

--- a/src/cmd/replica/mode.rs
+++ b/src/cmd/replica/mode.rs
@@ -75,6 +75,7 @@ mod tests {
     use super::*;
     use crate::cmd::replica::tests::prepare_replication;
     use crate::context::tests::{bucket, bucket2, context, replica};
+    use reduct_rs::ErrorCode;
     use rstest::rstest;
 
     #[rstest]
@@ -98,6 +99,14 @@ mod tests {
         let client = prepare_replication(&context, &test_replica, &bucket, &bucket2)
             .await
             .unwrap();
+
+        if let Err(err) = client.set_replication_mode(&test_replica, mode).await {
+            if err.status() == ErrorCode::MethodNotAllowed {
+                eprintln!("Server does not support replication mode endpoint yet.");
+                return;
+            }
+            panic!("{err:?}");
+        }
 
         match subcommand {
             "enable" => {

--- a/src/cmd/replica/mode.rs
+++ b/src/cmd/replica/mode.rs
@@ -9,7 +9,7 @@ use crate::io::reduct::build_client;
 use crate::io::std::output;
 use crate::parse::ResourcePathParser;
 use clap::{Arg, ArgMatches, Command};
-use reduct_rs::{ErrorCode, ReplicationMode};
+use reduct_rs::ReplicationMode;
 
 fn replication_mode_cmd(name: &'static str, about: &'static str) -> Command {
     Command::new(name).about(about).arg(
@@ -43,17 +43,7 @@ async fn set_replica_mode(
         .unwrap();
 
     let client = build_client(ctx, alias_or_url).await?;
-    if let Err(err) = client.set_replication_mode(replication_name, mode).await {
-        if err.status() == ErrorCode::MethodNotAllowed {
-            let mut settings = client.get_replication(replication_name).await?.settings;
-            settings.mode = mode;
-            client
-                .update_replication(replication_name, settings)
-                .await?;
-        } else {
-            return Err(err.into());
-        }
-    }
+    client.set_replication_mode(replication_name, mode).await?;
 
     output!(ctx, "Replication '{}' {}", replication_name, action);
     Ok(())

--- a/src/cmd/replica/mode.rs
+++ b/src/cmd/replica/mode.rs
@@ -1,0 +1,151 @@
+// Copyright 2026 ReductStore
+// This Source Code Form is subject to the terms of the Mozilla Public
+//    License, v. 2.0. If a copy of the MPL was not distributed with this
+//    file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use crate::cmd::RESOURCE_PATH_HELP;
+use crate::context::CliContext;
+use crate::io::reduct::build_client;
+use crate::io::std::output;
+use crate::parse::ResourcePathParser;
+use clap::{Arg, ArgMatches, Command};
+use reduct_rs::{ErrorCode, ReplicationMode};
+
+fn replication_mode_cmd(name: &'static str, about: &'static str) -> Command {
+    Command::new(name).about(about).arg(
+        Arg::new("REPLICATION_PATH")
+            .help(RESOURCE_PATH_HELP)
+            .value_parser(ResourcePathParser::new())
+            .required(true),
+    )
+}
+
+pub(super) fn enable_replica_cmd() -> Command {
+    replication_mode_cmd("enable", "Enable a replication task")
+}
+
+pub(super) fn disable_replica_cmd() -> Command {
+    replication_mode_cmd("disable", "Disable a replication task")
+}
+
+pub(super) fn pause_replica_cmd() -> Command {
+    replication_mode_cmd("pause", "Pause a replication task")
+}
+
+async fn set_replica_mode(
+    ctx: &CliContext,
+    args: &ArgMatches,
+    mode: ReplicationMode,
+    action: &str,
+) -> anyhow::Result<()> {
+    let (alias_or_url, replication_name) = args
+        .get_one::<(String, String)>("REPLICATION_PATH")
+        .unwrap();
+
+    let client = build_client(ctx, alias_or_url).await?;
+    if let Err(err) = client.set_replication_mode(replication_name, mode).await {
+        if err.status() == ErrorCode::MethodNotAllowed {
+            let mut settings = client.get_replication(replication_name).await?.settings;
+            settings.mode = mode;
+            client
+                .update_replication(replication_name, settings)
+                .await?;
+        } else {
+            return Err(err.into());
+        }
+    }
+
+    output!(ctx, "Replication '{}' {}", replication_name, action);
+    Ok(())
+}
+
+pub(super) async fn enable_replica_handler(
+    ctx: &CliContext,
+    args: &ArgMatches,
+) -> anyhow::Result<()> {
+    set_replica_mode(ctx, args, ReplicationMode::Enabled, "enabled").await
+}
+
+pub(super) async fn disable_replica_handler(
+    ctx: &CliContext,
+    args: &ArgMatches,
+) -> anyhow::Result<()> {
+    set_replica_mode(ctx, args, ReplicationMode::Disabled, "disabled").await
+}
+
+pub(super) async fn pause_replica_handler(
+    ctx: &CliContext,
+    args: &ArgMatches,
+) -> anyhow::Result<()> {
+    set_replica_mode(ctx, args, ReplicationMode::Paused, "paused").await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cmd::replica::tests::prepare_replication;
+    use crate::context::tests::{bucket, bucket2, context, replica};
+    use rstest::rstest;
+
+    #[rstest]
+    #[tokio::test]
+    #[case::enable("enable", ReplicationMode::Enabled, "enabled")]
+    #[case::disable("disable", ReplicationMode::Disabled, "disabled")]
+    #[case::pause("pause", ReplicationMode::Paused, "paused")]
+    async fn test_set_replica_mode(
+        context: CliContext,
+        #[future] replica: String,
+        #[future] bucket: String,
+        #[future] bucket2: String,
+        #[case] subcommand: &str,
+        #[case] mode: ReplicationMode,
+        #[case] action: &str,
+    ) {
+        let test_replica = replica.await;
+        let bucket = bucket.await;
+        let bucket2 = bucket2.await;
+
+        let client = prepare_replication(&context, &test_replica, &bucket, &bucket2)
+            .await
+            .unwrap();
+
+        match subcommand {
+            "enable" => {
+                let args = enable_replica_cmd()
+                    .try_get_matches_from(vec![
+                        subcommand,
+                        format!("local/{}", test_replica).as_str(),
+                    ])
+                    .unwrap();
+                enable_replica_handler(&context, &args).await.unwrap();
+            }
+            "disable" => {
+                let args = disable_replica_cmd()
+                    .try_get_matches_from(vec![
+                        subcommand,
+                        format!("local/{}", test_replica).as_str(),
+                    ])
+                    .unwrap();
+                disable_replica_handler(&context, &args).await.unwrap();
+            }
+            "pause" => {
+                let args = pause_replica_cmd()
+                    .try_get_matches_from(vec![
+                        subcommand,
+                        format!("local/{}", test_replica).as_str(),
+                    ])
+                    .unwrap();
+                pause_replica_handler(&context, &args).await.unwrap();
+            }
+            _ => unreachable!(),
+        }
+
+        let replica = client.get_replication(&test_replica).await.unwrap();
+        assert_eq!(replica.info.mode, mode);
+        assert_eq!(replica.settings.mode, mode);
+        assert_eq!(
+            context.stdout().history(),
+            vec![format!("Replication '{}' {}", test_replica, action)]
+        );
+    }
+}

--- a/src/cmd/table.rs
+++ b/src/cmd/table.rs
@@ -1,0 +1,47 @@
+// Shared helpers for rendering borderless info tables in CLI commands.
+use crate::helpers::timestamp_to_iso;
+use tabled::settings::Style;
+use tabled::{Table, Tabled};
+
+const DEFAULT_COLUMNS: usize = 2;
+
+#[derive(Tabled)]
+struct InfoGridRow {
+    #[tabled(rename = "")]
+    left: String,
+    #[tabled(rename = "")]
+    right: String,
+}
+
+pub(crate) fn labeled_cell(label: &str, value: impl ToString) -> String {
+    format!("{}: {}", label, value.to_string())
+}
+
+pub(crate) fn build_info_table(cells: Vec<String>) -> String {
+    build_info_table_with_columns(cells, DEFAULT_COLUMNS)
+}
+
+pub(crate) fn build_info_table_with_columns(cells: Vec<String>, columns: usize) -> String {
+    assert!(columns >= 1, "table must have at least one column");
+
+    let mut rows = Vec::new();
+    for chunk in cells.chunks(columns) {
+        let left = chunk.get(0).cloned().unwrap_or_default();
+        let right = chunk.get(1).cloned().unwrap_or_default();
+        rows.push(InfoGridRow { left, right });
+    }
+
+    Table::new(rows).with(Style::blank()).to_string()
+}
+
+pub(crate) fn record_range_cells(oldest: u64, latest: u64, is_empty: bool) -> Vec<String> {
+    let oldest_value = timestamp_to_iso(oldest, is_empty);
+    let latest_value = timestamp_to_iso(latest, is_empty);
+
+    vec![
+        format!("Oldest Record (UTC): {}", oldest_value),
+        String::new(),
+        format!("Latest Record (UTC): {}", latest_value),
+        String::new(),
+    ]
+}


### PR DESCRIPTION
Closes #153

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature / CLI enhancement

### What was changed?

- Added replica mode subcommands to enable/disable/pause replication tasks, with a fallback to full settings update when the mode endpoint is unavailable.
- Included replication mode in list/show outputs and aligned replica/bucket views on the shared info table formatting.
- Added tests for replica mode commands and updated output expectations.

### Related issues

- #153

### Does this PR introduce a breaking change?

No.

### Other information:

Tests: `RS_API_TOKEN=TOKEN cargo test replica::mode`
