### PR TITLE
Add --from-last for incremental bucket copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add batching in reduct-cli for cp command, [PR-148](https://github.com/reductstore/reduct-cli/pull/148)
 - Show bucket status and update copy/removal handling, [PR-167](https://github.com/reductstore/reduct-cli/pull/167)
 - Add replica mode commands and mode-aware outputs, [PR-168](https://github.com/reductstore/reduct-cli/pull/168)
+- Add --from-last option for incremental cp, [PR-169](https://github.com/reductstore/reduct-cli/pull/169)
 
 ## 0.9.4 - 2025-12-17
 

--- a/src/cmd/cp.rs
+++ b/src/cmd/cp.rs
@@ -42,6 +42,13 @@ pub(crate) fn cp_cmd() -> Command {
                 .required(false)
         )
         .arg(
+            Arg::new("from-last")
+                .long("from-last")
+                .help("Copy records starting after the latest record in each destination entry.")
+                .required(false)
+                .action(SetTrue)
+        )
+        .arg(
             Arg::new("stop")
                 .long("stop")
                 .short('e')

--- a/src/cmd/cp/b2f.rs
+++ b/src/cmd/cp/b2f.rs
@@ -151,6 +151,12 @@ impl CopyToFolderVisitor {
 }
 
 pub(crate) async fn cp_bucket_to_folder(ctx: &CliContext, args: &ArgMatches) -> anyhow::Result<()> {
+    if args.get_flag("from-last") {
+        return Err(anyhow::anyhow!(
+            "--from-last is only supported for bucket-to-bucket copy"
+        ));
+    }
+
     let (src_instance, src_bucket) = args
         .get_one::<(String, String)>("SOURCE_BUCKET_OR_FOLDER")
         .map(|(src_instance, src_bucket)| (src_instance.clone(), src_bucket.clone()))


### PR DESCRIPTION
Closes #142

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

- Add `--from-last` for `cp` bucket-to-bucket to start after the latest record in destination entries
- Guard against using `--from-last` with `--start` or bucket-to-folder copy
- Refactor copy helper for clarity and adjust progress handling
- Add tests for `--from-last` behavior

### Related issues

- #142

### Does this PR introduce a breaking change?

No

### Other information:

N/A
