### PR TITLE
Fix cp parsing for base-path URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## Unreleased
+
+## 0.10.1 - 2026-02-04
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix cp parsing for base-path URLs, [PR-176](https://github.com/reductstore/reduct-cli/pull/176)
+
 ## 0.10.0 - 2026-02-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,7 +1320,7 @@ dependencies = [
 
 [[package]]
 name = "reduct-cli"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reduct-cli"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 authors = ["Alexey Timin <atimin@reduct.store>"]
 rust-version = "1.89.0"

--- a/src/cmd/cp.rs
+++ b/src/cmd/cp.rs
@@ -425,7 +425,11 @@ mod tests {
         let dst = args
             .get_one::<CpPath>("DESTINATION_BUCKET_OR_FOLDER")
             .unwrap();
-        assert!(matches!(dst, CpPath::Instance(value) if value == "https://example.com"));
+        assert!(matches!(
+            dst,
+            CpPath::Instance(value)
+            if value == "https://example.com/"
+        ));
 
         let result = cp_handler(&context, &args).await;
         assert!(result.is_err());

--- a/src/cmd/cp.rs
+++ b/src/cmd/cp.rs
@@ -52,27 +52,33 @@ impl TypedValueParser for CpPathParser {
             return Ok(CpPath::Folder(value));
         }
 
-        if let Ok(url) = Url::parse(&value) {
+        if let Ok(mut url) = Url::parse(&value) {
             let scheme = url.scheme();
             if scheme == "http" || scheme == "https" {
-                let path = url.path().trim_start_matches('/');
-                let bucket = path.trim_end_matches('/');
-                if bucket.is_empty() {
-                    return Ok(CpPath::Instance(value));
+                url.set_query(None);
+                url.set_fragment(None);
+
+                let path = url.path();
+                let has_trailing_slash = path.ends_with('/') && path != "/";
+                let mut segments: Vec<&str> = url
+                    .path_segments()
+                    .map(|segments| segments.filter(|segment| !segment.is_empty()).collect())
+                    .unwrap_or_default();
+
+                if segments.is_empty() || has_trailing_slash {
+                    return Ok(CpPath::Instance(url.to_string()));
                 }
-                if bucket.contains('/') {
-                    let mut err = Error::new(ErrorKind::ValueValidation).with_cmd(cmd);
-                    err.insert(
-                        ContextKind::InvalidArg,
-                        ContextValue::String(arg.unwrap().to_string()),
-                    );
-                    err.insert(ContextKind::InvalidValue, ContextValue::String(value));
-                    return Err(err);
-                }
+
+                let bucket = segments
+                    .pop()
+                    .ok_or_else(|| Error::new(ErrorKind::ValueValidation).with_cmd(cmd))?;
+                let base_path = if segments.is_empty() {
+                    "/".to_string()
+                } else {
+                    format!("/{}/", segments.join("/"))
+                };
                 let mut base_url = url.clone();
-                base_url.set_path("/");
-                base_url.set_query(None);
-                base_url.set_fragment(None);
+                base_url.set_path(&base_path);
                 return Ok(CpPath::Bucket {
                     instance: base_url.to_string(),
                     bucket: bucket.to_string(),
@@ -423,6 +429,38 @@ mod tests {
 
         let result = cp_handler(&context, &args).await;
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn url_with_base_path_parses_bucket() {
+        let args = cp_cmd()
+            .try_get_matches_from(vec![
+                "cp",
+                "https://reductstore@play.reduct.store/replica/datasets",
+                "./tmp",
+            ])
+            .unwrap();
+        let src = args.get_one::<CpPath>("SOURCE_BUCKET_OR_FOLDER").unwrap();
+        assert!(matches!(
+            src,
+            CpPath::Bucket { instance, bucket }
+            if instance == "https://reductstore@play.reduct.store/replica/" && bucket == "datasets"
+        ));
+    }
+
+    #[test]
+    fn url_with_trailing_slash_parses_as_instance() {
+        let args = cp_cmd()
+            .try_get_matches_from(vec!["cp", "local/bucket", "https://example.com/api/"])
+            .unwrap();
+        let dst = args
+            .get_one::<CpPath>("DESTINATION_BUCKET_OR_FOLDER")
+            .unwrap();
+        assert!(matches!(
+            dst,
+            CpPath::Instance(value)
+            if value == "https://example.com/api/"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Closes #175

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix.

### What was changed?

- Adjusted cp URL parsing to support instance URLs with base paths and treat trailing slash paths as instances.
- Added regression tests covering base-path URLs and trailing-slash behavior.

### Related issues

- #175

### Does this PR introduce a breaking change?

No.

### Other information:

N/A
