### PR TITLE
Add Linux ARM32 binary artifact to CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
           [
             "x86_64-unknown-linux-gnu",
             "aarch64-unknown-linux-gnu",
+            "armv7-unknown-linux-gnueabihf",
             "x86_64-pc-windows-gnu",
             "x86_64-apple-darwin",
             "aarch64-apple-darwin",
@@ -50,6 +51,9 @@ jobs:
           - target: "aarch64-unknown-linux-gnu"
             os: ubuntu-24.04
             compiler: "gcc-aarch64-linux-gnu"
+          - target: "armv7-unknown-linux-gnueabihf"
+            os: ubuntu-24.04
+            compiler: "gcc-arm-linux-gnueabihf"
           - target: "x86_64-pc-windows-gnu"
             os: ubuntu-24.04
             compiler: "gcc-mingw-w64-x86-64"
@@ -196,6 +200,7 @@ jobs:
         target: [
           "x86_64-unknown-linux-gnu",
           "aarch64-unknown-linux-gnu",
+          "armv7-unknown-linux-gnueabihf",
           "x86_64-pc-windows-gnu",
           "x86_64-apple-darwin",
           "aarch64-apple-darwin",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Add Linux ARM32 CI/CD artifacts, [PR-177](https://github.com/reductstore/reduct-cli/pull/177)
+
 ## 0.10.1 - 2026-02-04
 
 ### Fixed


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

- Added `armv7-unknown-linux-gnueabihf` to the build target matrix in CI.
- Added Ubuntu cross-compiler setup for ARM32 (`gcc-arm-linux-gnueabihf`).
- Added `armv7-unknown-linux-gnueabihf` to the release upload matrix so tagged releases publish `reduct-cli.armv7-unknown-linux-gnueabihf.tar.gz`.

### Related issues

N/A

### Does this PR introduce a breaking change?

No.

### Other information:

No runtime code changes; this updates only GitHub Actions workflow configuration.
