### PR TITLE
Add global --ca-cert, persist alias options, and use reduct-rs main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `attachment write`, `attachment ls`, `attachment read`, and `attachment rm` commands for entry attachments, [PR-184](https://github.com/reductstore/reduct-cli/pull/184)
+- Add global `--ca-cert` and persist alias connection options (`--ca-cert`, `--ignore-ssl`, `--timeout`, `--parallel`) in `alias add`, [PR-189](https://github.com/reductstore/reduct-cli/pull/189)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,9 +22,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -37,15 +37,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -134,6 +134,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,13 +193,21 @@ checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -207,18 +237,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -228,15 +258,24 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "colored"
@@ -244,7 +283,17 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -258,13 +307,12 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
  "unicode-width",
  "windows-sys 0.61.2",
 ]
@@ -296,6 +344,16 @@ dependencies = [
  "serde_json",
  "time",
  "url",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -379,6 +437,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,7 +461,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -459,6 +523,12 @@ name = "fragile"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -576,20 +646,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -695,7 +765,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -892,9 +961,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
@@ -919,10 +988,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
-name = "js-sys"
-version = "0.3.90"
+name = "jni"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dc6f6450b3f6d4ed5b16327f38fed626d375a886159ca555bd7822c0c3a5a6"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -936,17 +1037,16 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libredox"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
- "bitflags",
  "libc",
 ]
 
@@ -1056,15 +1156,21 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "option-ext"
@@ -1097,9 +1203,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -1175,9 +1281,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
 ]
@@ -1255,7 +1361,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1267,6 +1373,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -1276,7 +1383,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1293,14 +1400,14 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1310,6 +1417,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -1348,7 +1461,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1401,8 +1514,8 @@ dependencies = [
 
 [[package]]
 name = "reduct-rs"
-version = "1.18.0"
-source = "git+https://github.com/reductstore/reduct-rs?branch=main#59330b9cd5d372a2a23ddba3181f2868b1c30ad3"
+version = "1.19.0"
+source = "git+https://github.com/reductstore/reduct-rs?branch=main#cc277c4ce40fe7550b66a0ab4496a31fe4169c91"
 dependencies = [
  "async-channel",
  "async-stream",
@@ -1455,9 +1568,9 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64",
  "bytes",
@@ -1478,9 +1591,9 @@ dependencies = [
  "quinn",
  "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -1493,7 +1606,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1564,7 +1676,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1573,12 +1685,24 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -1592,11 +1716,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -1609,10 +1761,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "ryu"
-version = "1.0.23"
+name = "same-file"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -1674,18 +1861,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1711,12 +1886,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1794,15 +1969,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1822,11 +1997,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1899,9 +2094,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1929,9 +2124,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1970,7 +2165,7 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow",
@@ -1986,13 +2181,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+name = "toml_datetime"
+version = "1.0.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.4+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.0.0+spec-1.1.0",
  "toml_parser",
  "winnow",
 ]
@@ -2150,6 +2354,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2184,9 +2398,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.113"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60722a937f594b7fde9adb894d7c092fc1bb6612897c46368d18e7a20208eff2"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2197,9 +2411,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.63"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a89f4650b770e4521aa6573724e2aed4704372151bd0de9d16a3bbabb87441a"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2211,9 +2425,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.113"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac8c6395094b6b91c4af293f4c79371c163f9a6f56184d2c9a85f5a95f3950"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2221,9 +2435,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.113"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3fabce6159dc20728033842636887e4877688ae94382766e00b180abac9d60"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2234,9 +2448,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.113"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0e091bdb824da87dc01d967388880d017a0a9bc4f3bdc0d86ee9f9336e3bb5"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
@@ -2265,9 +2479,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -2290,9 +2504,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.90"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705eceb4ce901230f8625bd1d665128056ccbe4b7408faa625eec1ba80f59a97"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2309,12 +2523,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
+name = "webpki-root-certs"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2378,6 +2601,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -2401,6 +2633,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -2438,6 +2685,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -2450,6 +2703,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -2459,6 +2718,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2486,6 +2751,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -2495,6 +2766,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2510,6 +2787,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -2519,6 +2802,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2534,9 +2823,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
@@ -2660,18 +2949,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,7 +244,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -397,7 +397,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1263,9 +1263,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -1293,7 +1293,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1564,7 +1564,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1802,7 +1802,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1914,9 +1914,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://reduct.store/docs/guides"
 description = "A CLI client for ReductStore written in Rust"
 
 [dependencies]
-reduct-rs =  { version = "1.18.0", git = "https://github.com/reductstore/reduct-rs", branch = "main"}
+reduct-rs =  { version = "1.19.0", git = "https://github.com/reductstore/reduct-rs", branch = "main" }
 clap = { version = "4.5.53", features = ["cargo"] }
 dirs = "6.0.0"
 toml = "0.9.8"

--- a/src/cmd/alias/add.rs
+++ b/src/cmd/alias/add.rs
@@ -25,6 +25,10 @@ pub(super) fn add_alias(ctx: &CliContext, args: &ArgMatches) -> anyhow::Result<(
         Alias {
             url: Url::parse(url)?,
             token: token.map(|t: &String| t.to_string()).unwrap_or_default(),
+            ignore_ssl: ctx.ignore_ssl(),
+            timeout: ctx.timeout().as_secs(),
+            parallel: ctx.parallel(),
+            ca_cert: ctx.ca_cert().cloned(),
         },
     );
     config_file.save()?;
@@ -55,7 +59,11 @@ pub(super) fn add_alias_cmd() -> Command {
 mod tests {
     use super::*;
     use crate::context::tests::context;
+    use crate::context::{ContextBuilder, DEFAULT_PARALLEL};
+    use crate::io::std::Output;
     use rstest::rstest;
+    use std::time::Duration;
+    use tempfile::tempdir;
 
     #[rstest]
     fn test_add_alias(context: CliContext) {
@@ -77,6 +85,10 @@ mod tests {
             Alias {
                 url: Url::parse("https://test.reduct.store").unwrap(),
                 token: "test_token".to_string(),
+                ignore_ssl: false,
+                timeout: 30,
+                parallel: 10,
+                ca_cert: None,
             }
         );
     }
@@ -123,5 +135,35 @@ mod tests {
             result.err().unwrap().to_string(),
             "Alias 'test' already exists"
         );
+    }
+
+    #[rstest]
+    fn test_add_alias_persists_connection_options() {
+        let tmp_dir = tempdir().unwrap();
+        let context = ContextBuilder::new()
+            .config_path(tmp_dir.path().join("config.toml").to_str().unwrap())
+            .output(Box::new(crate::context::tests::MockOutput::new()) as Box<dyn Output>)
+            .ignore_ssl(true)
+            .timeout(Duration::from_secs(15))
+            .parallel(DEFAULT_PARALLEL + 1)
+            .ca_cert(Some("/tmp/custom-ca.pem".to_string()))
+            .build();
+
+        let args = add_alias_cmd().get_matches_from(vec![
+            "add",
+            "test",
+            "-L",
+            "https://test.reduct.store",
+            "-t",
+            "test_token",
+        ]);
+        add_alias(&context, &args).unwrap();
+
+        let config_file = ConfigFile::load(context.config_path()).unwrap();
+        let alias = config_file.config().aliases.get("test").unwrap();
+        assert_eq!(alias.ignore_ssl, true);
+        assert_eq!(alias.timeout, 15);
+        assert_eq!(alias.parallel, DEFAULT_PARALLEL + 1);
+        assert_eq!(alias.ca_cert, Some("/tmp/custom-ca.pem".to_string()));
     }
 }

--- a/src/cmd/alias/add.rs
+++ b/src/cmd/alias/add.rs
@@ -4,7 +4,7 @@
 //    file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use crate::config::{Alias, ConfigFile};
-use crate::context::CliContext;
+use crate::context::{CliContext, DEFAULT_PARALLEL, DEFAULT_TIMEOUT_SECS};
 use anyhow::Error;
 use clap::{arg, Arg, ArgMatches, Command};
 use url::Url;
@@ -25,9 +25,12 @@ pub(super) fn add_alias(ctx: &CliContext, args: &ArgMatches) -> anyhow::Result<(
         Alias {
             url: Url::parse(url)?,
             token: token.map(|t: &String| t.to_string()).unwrap_or_default(),
-            ignore_ssl: ctx.ignore_ssl(),
-            timeout: ctx.timeout().as_secs(),
-            parallel: ctx.parallel(),
+            ignore_ssl: ctx.ignore_ssl().unwrap_or(false),
+            timeout: ctx
+                .timeout()
+                .map(|timeout| timeout.as_secs())
+                .unwrap_or(DEFAULT_TIMEOUT_SECS),
+            parallel: ctx.parallel().unwrap_or(DEFAULT_PARALLEL),
             ca_cert: ctx.ca_cert().cloned(),
         },
     );
@@ -59,7 +62,7 @@ pub(super) fn add_alias_cmd() -> Command {
 mod tests {
     use super::*;
     use crate::context::tests::context;
-    use crate::context::{ContextBuilder, DEFAULT_PARALLEL};
+    use crate::context::ContextBuilder;
     use crate::io::std::Output;
     use rstest::rstest;
     use std::time::Duration;
@@ -143,9 +146,9 @@ mod tests {
         let context = ContextBuilder::new()
             .config_path(tmp_dir.path().join("config.toml").to_str().unwrap())
             .output(Box::new(crate::context::tests::MockOutput::new()) as Box<dyn Output>)
-            .ignore_ssl(true)
-            .timeout(Duration::from_secs(15))
-            .parallel(DEFAULT_PARALLEL + 1)
+            .ignore_ssl(Some(true))
+            .timeout(Some(Duration::from_secs(15)))
+            .parallel(Some(DEFAULT_PARALLEL + 1))
             .ca_cert(Some("/tmp/custom-ca.pem".to_string()))
             .build();
 

--- a/src/cmd/cp/b2b.rs
+++ b/src/cmd/cp/b2b.rs
@@ -82,7 +82,7 @@ pub(crate) async fn cp_bucket_to_bucket_with(
     dst_instance: &str,
     dst_bucket: &str,
 ) -> anyhow::Result<()> {
-    let query_params = parse_query_params(ctx, &args)?;
+    let query_params = parse_query_params(ctx, &args, Some(src_instance))?;
     let from_last = args.get_flag("from-last");
     if from_last && args.get_one::<String>("start").is_some() {
         return Err(anyhow::anyhow!("--from-last can't be used with --start"));

--- a/src/cmd/cp/b2f.rs
+++ b/src/cmd/cp/b2f.rs
@@ -189,7 +189,7 @@ pub(crate) async fn cp_bucket_to_folder(ctx: &CliContext, args: &ArgMatches) -> 
         }
     };
 
-    let query_params = parse_query_params(ctx, &args)?;
+    let query_params = parse_query_params(ctx, &args, Some(&src_instance))?;
     let src_bucket = build_client(ctx, &src_instance)
         .await?
         .get_bucket(&src_bucket)

--- a/src/cmd/rm.rs
+++ b/src/cmd/rm.rs
@@ -65,7 +65,7 @@ pub(crate) fn rm_cmd() -> Command {
 
 pub(crate) async fn rm_handler(ctx: &CliContext, args: &clap::ArgMatches) -> anyhow::Result<()> {
     let (alias, bucket) = args.get_one::<(String, String)>("BUCKET_PATH").unwrap();
-    let query_params = parse_query_params(ctx, &args)?;
+    let query_params = parse_query_params(ctx, &args, Some(alias.as_str()))?;
     let timestamps = args
         .get_many::<String>("time")
         .map(|values| values.map(|s| s.clone()).collect::<Vec<String>>());

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,7 @@ use crate::context::CliContext;
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use std::time::Duration;
 
 use std::path::PathBuf;
 use url::Url;
@@ -14,6 +15,22 @@ use url::Url;
 pub(crate) struct Alias {
     pub url: Url,
     pub token: String,
+    #[serde(default)]
+    pub ignore_ssl: bool,
+    #[serde(default = "default_timeout")]
+    pub timeout: u64,
+    #[serde(default = "default_parallel")]
+    pub parallel: usize,
+    #[serde(default)]
+    pub ca_cert: Option<String>,
+}
+
+fn default_timeout() -> u64 {
+    crate::context::DEFAULT_TIMEOUT_SECS
+}
+
+fn default_parallel() -> usize {
+    crate::context::DEFAULT_PARALLEL
 }
 
 #[derive(Deserialize, Serialize, PartialEq, Debug)]
@@ -77,6 +94,55 @@ pub(crate) fn find_alias(ctx: &CliContext, alias: &str) -> anyhow::Result<Alias>
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ConnectionOptions {
+    pub ignore_ssl: bool,
+    pub timeout: Duration,
+    pub parallel: usize,
+    pub ca_cert: Option<String>,
+}
+
+pub(crate) fn resolve_connection_options(
+    ctx: &CliContext,
+    alias_or_url: &str,
+) -> ConnectionOptions {
+    let alias_options = find_alias(ctx, alias_or_url).ok();
+    ConnectionOptions {
+        ignore_ssl: if ctx.ignore_ssl_overridden() {
+            ctx.ignore_ssl()
+        } else {
+            alias_options
+                .as_ref()
+                .map(|alias| alias.ignore_ssl)
+                .unwrap_or(ctx.ignore_ssl())
+        },
+        timeout: if ctx.timeout_overridden() {
+            ctx.timeout()
+        } else {
+            alias_options
+                .as_ref()
+                .map(|alias| Duration::from_secs(alias.timeout))
+                .unwrap_or(ctx.timeout())
+        },
+        parallel: if ctx.parallel_overridden() {
+            ctx.parallel()
+        } else {
+            alias_options
+                .as_ref()
+                .map(|alias| alias.parallel)
+                .unwrap_or(ctx.parallel())
+        },
+        ca_cert: if ctx.ca_cert_overridden() {
+            ctx.ca_cert().cloned()
+        } else {
+            alias_options
+                .as_ref()
+                .and_then(|alias| alias.ca_cert.clone())
+                .or_else(|| ctx.ca_cert().cloned())
+        },
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -84,9 +150,10 @@ mod tests {
     use std::fs;
     use std::fs::File;
     use std::io::Write;
+    use std::time::Duration;
 
-    use crate::context::tests::context;
-    use crate::context::CliContext;
+    use crate::context::tests::{context, output};
+    use crate::context::{CliContext, ContextBuilder};
 
     #[rstest]
     fn test_load(context: CliContext) {
@@ -108,6 +175,9 @@ mod tests {
             "https://test.com/"
         );
         assert_eq!(config.aliases.get("test").unwrap().token, "test");
+        assert_eq!(config.aliases.get("test").unwrap().timeout, 30);
+        assert_eq!(config.aliases.get("test").unwrap().parallel, 10);
+        assert_eq!(config.aliases.get("test").unwrap().ca_cert, None);
     }
 
     #[rstest]
@@ -119,6 +189,10 @@ mod tests {
             Alias {
                 url: Url::parse("https://test.com").unwrap(),
                 token: "test".to_string(),
+                ignore_ssl: false,
+                timeout: 30,
+                parallel: 10,
+                ca_cert: None,
             },
         )]
         .into_iter()
@@ -137,5 +211,46 @@ mod tests {
     fn test_empty_config(context: CliContext) {
         let config_file = ConfigFile::load(&format!("{}.empty", context.config_path())).unwrap();
         assert_eq!(config_file.config().aliases.len(), 0);
+    }
+
+    #[rstest]
+    fn test_resolve_connection_options_from_alias(context: CliContext) {
+        let mut config_file = ConfigFile::load(context.config_path()).unwrap();
+        let alias = config_file.mut_config().aliases.get_mut("default").unwrap();
+        alias.ignore_ssl = true;
+        alias.timeout = 7;
+        alias.parallel = 2;
+        alias.ca_cert = Some("/tmp/test.crt".to_string());
+        config_file.save().unwrap();
+
+        let options = resolve_connection_options(&context, "default");
+        assert_eq!(options.ignore_ssl, true);
+        assert_eq!(options.timeout, Duration::from_secs(7));
+        assert_eq!(options.parallel, 2);
+        assert_eq!(options.ca_cert, Some("/tmp/test.crt".to_string()));
+    }
+
+    #[rstest]
+    fn test_resolve_connection_options_cli_override(
+        context: CliContext,
+        output: Box<dyn crate::io::std::Output>,
+    ) {
+        let ctx = ContextBuilder::new()
+            .config_path(context.config_path())
+            .output(output)
+            .ignore_ssl(false)
+            .ignore_ssl_overridden(false)
+            .timeout(Duration::from_secs(5))
+            .timeout_overridden(true)
+            .parallel(4)
+            .parallel_overridden(true)
+            .ca_cert(Some("/tmp/override.crt".to_string()))
+            .ca_cert_overridden(true)
+            .build();
+
+        let options = resolve_connection_options(&ctx, "default");
+        assert_eq!(options.timeout, Duration::from_secs(5));
+        assert_eq!(options.parallel, 4);
+        assert_eq!(options.ca_cert, Some("/tmp/override.crt".to_string()));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -108,38 +108,27 @@ pub(crate) fn resolve_connection_options(
 ) -> ConnectionOptions {
     let alias_options = find_alias(ctx, alias_or_url).ok();
     ConnectionOptions {
-        ignore_ssl: if ctx.ignore_ssl_overridden() {
-            ctx.ignore_ssl()
-        } else {
-            alias_options
-                .as_ref()
-                .map(|alias| alias.ignore_ssl)
-                .unwrap_or(ctx.ignore_ssl())
-        },
-        timeout: if ctx.timeout_overridden() {
-            ctx.timeout()
-        } else {
-            alias_options
-                .as_ref()
-                .map(|alias| Duration::from_secs(alias.timeout))
-                .unwrap_or(ctx.timeout())
-        },
-        parallel: if ctx.parallel_overridden() {
-            ctx.parallel()
-        } else {
-            alias_options
-                .as_ref()
-                .map(|alias| alias.parallel)
-                .unwrap_or(ctx.parallel())
-        },
-        ca_cert: if ctx.ca_cert_overridden() {
-            ctx.ca_cert().cloned()
-        } else {
+        ignore_ssl: ctx
+            .ignore_ssl()
+            .or_else(|| alias_options.as_ref().map(|alias| alias.ignore_ssl))
+            .unwrap_or(false),
+        timeout: ctx
+            .timeout()
+            .or_else(|| {
+                alias_options
+                    .as_ref()
+                    .map(|alias| Duration::from_secs(alias.timeout))
+            })
+            .unwrap_or(crate::context::DEFAULT_TIMEOUT),
+        parallel: ctx
+            .parallel()
+            .or_else(|| alias_options.as_ref().map(|alias| alias.parallel))
+            .unwrap_or(crate::context::DEFAULT_PARALLEL),
+        ca_cert: ctx.ca_cert().cloned().or_else(|| {
             alias_options
                 .as_ref()
                 .and_then(|alias| alias.ca_cert.clone())
-                .or_else(|| ctx.ca_cert().cloned())
-        },
+        }),
     }
 }
 
@@ -238,14 +227,10 @@ mod tests {
         let ctx = ContextBuilder::new()
             .config_path(context.config_path())
             .output(output)
-            .ignore_ssl(false)
-            .ignore_ssl_overridden(false)
-            .timeout(Duration::from_secs(5))
-            .timeout_overridden(true)
-            .parallel(4)
-            .parallel_overridden(true)
+            .ignore_ssl(Some(false))
+            .timeout(Some(Duration::from_secs(5)))
+            .parallel(Some(4))
             .ca_cert(Some("/tmp/override.crt".to_string()))
-            .ca_cert_overridden(true)
             .build();
 
         let options = resolve_connection_options(&ctx, "default");

--- a/src/context.rs
+++ b/src/context.rs
@@ -15,14 +15,10 @@ pub(crate) const DEFAULT_PARALLEL: usize = 10;
 pub(crate) struct CliContext {
     config_path: String,
     output: Box<dyn Output>,
-    ignore_ssl: bool,
-    ignore_ssl_overridden: bool,
-    timeout: Duration,
-    timeout_overridden: bool,
-    parallel: usize,
-    parallel_overridden: bool,
+    ignore_ssl: Option<bool>,
+    timeout: Option<Duration>,
+    parallel: Option<usize>,
     ca_cert: Option<String>,
-    ca_cert_overridden: bool,
 }
 
 impl CliContext {
@@ -33,36 +29,20 @@ impl CliContext {
         &*self.output
     }
 
-    pub(crate) fn ignore_ssl(&self) -> bool {
+    pub(crate) fn ignore_ssl(&self) -> Option<bool> {
         self.ignore_ssl
     }
 
-    pub(crate) fn ignore_ssl_overridden(&self) -> bool {
-        self.ignore_ssl_overridden
-    }
-
-    pub(crate) fn timeout(&self) -> Duration {
+    pub(crate) fn timeout(&self) -> Option<Duration> {
         self.timeout
     }
 
-    pub(crate) fn timeout_overridden(&self) -> bool {
-        self.timeout_overridden
-    }
-
-    pub(crate) fn parallel(&self) -> usize {
+    pub(crate) fn parallel(&self) -> Option<usize> {
         self.parallel
-    }
-
-    pub(crate) fn parallel_overridden(&self) -> bool {
-        self.parallel_overridden
     }
 
     pub(crate) fn ca_cert(&self) -> Option<&String> {
         self.ca_cert.as_ref()
-    }
-
-    pub(crate) fn ca_cert_overridden(&self) -> bool {
-        self.ca_cert_overridden
     }
 }
 
@@ -75,14 +55,10 @@ impl ContextBuilder {
         let mut config = CliContext {
             config_path: String::new(),
             output: Box::new(StdOutput::new()),
-            ignore_ssl: false,
-            ignore_ssl_overridden: false,
-            timeout: DEFAULT_TIMEOUT,
-            timeout_overridden: false,
-            parallel: DEFAULT_PARALLEL,
-            parallel_overridden: false,
+            ignore_ssl: None,
+            timeout: None,
+            parallel: None,
             ca_cert: None,
-            ca_cert_overridden: false,
         };
         config.config_path = match home_dir() {
             Some(path) => path
@@ -111,43 +87,23 @@ impl ContextBuilder {
         self
     }
 
-    pub(crate) fn ignore_ssl(mut self, ignore_ssl: bool) -> Self {
+    pub(crate) fn ignore_ssl(mut self, ignore_ssl: Option<bool>) -> Self {
         self.config.ignore_ssl = ignore_ssl;
         self
     }
 
-    pub(crate) fn ignore_ssl_overridden(mut self, overridden: bool) -> Self {
-        self.config.ignore_ssl_overridden = overridden;
-        self
-    }
-
-    pub(crate) fn timeout(mut self, timeout: Duration) -> Self {
+    pub(crate) fn timeout(mut self, timeout: Option<Duration>) -> Self {
         self.config.timeout = timeout;
         self
     }
 
-    pub(crate) fn timeout_overridden(mut self, overridden: bool) -> Self {
-        self.config.timeout_overridden = overridden;
-        self
-    }
-
-    pub(crate) fn parallel(mut self, parallel: usize) -> Self {
+    pub(crate) fn parallel(mut self, parallel: Option<usize>) -> Self {
         self.config.parallel = parallel;
-        self
-    }
-
-    pub(crate) fn parallel_overridden(mut self, overridden: bool) -> Self {
-        self.config.parallel_overridden = overridden;
         self
     }
 
     pub(crate) fn ca_cert(mut self, ca_cert: Option<String>) -> Self {
         self.config.ca_cert = ca_cert;
-        self
-    }
-
-    pub(crate) fn ca_cert_overridden(mut self, overridden: bool) -> Self {
-        self.config.ca_cert_overridden = overridden;
         self
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -8,12 +8,21 @@ use dirs::home_dir;
 use std::env::current_dir;
 use std::time::Duration;
 
+pub(crate) const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+pub(crate) const DEFAULT_TIMEOUT_SECS: u64 = 30;
+pub(crate) const DEFAULT_PARALLEL: usize = 10;
+
 pub(crate) struct CliContext {
     config_path: String,
     output: Box<dyn Output>,
     ignore_ssl: bool,
+    ignore_ssl_overridden: bool,
     timeout: Duration,
+    timeout_overridden: bool,
     parallel: usize,
+    parallel_overridden: bool,
+    ca_cert: Option<String>,
+    ca_cert_overridden: bool,
 }
 
 impl CliContext {
@@ -28,12 +37,32 @@ impl CliContext {
         self.ignore_ssl
     }
 
+    pub(crate) fn ignore_ssl_overridden(&self) -> bool {
+        self.ignore_ssl_overridden
+    }
+
     pub(crate) fn timeout(&self) -> Duration {
         self.timeout
     }
 
+    pub(crate) fn timeout_overridden(&self) -> bool {
+        self.timeout_overridden
+    }
+
     pub(crate) fn parallel(&self) -> usize {
         self.parallel
+    }
+
+    pub(crate) fn parallel_overridden(&self) -> bool {
+        self.parallel_overridden
+    }
+
+    pub(crate) fn ca_cert(&self) -> Option<&String> {
+        self.ca_cert.as_ref()
+    }
+
+    pub(crate) fn ca_cert_overridden(&self) -> bool {
+        self.ca_cert_overridden
     }
 }
 
@@ -47,8 +76,13 @@ impl ContextBuilder {
             config_path: String::new(),
             output: Box::new(StdOutput::new()),
             ignore_ssl: false,
-            timeout: Duration::from_secs(30),
-            parallel: 10,
+            ignore_ssl_overridden: false,
+            timeout: DEFAULT_TIMEOUT,
+            timeout_overridden: false,
+            parallel: DEFAULT_PARALLEL,
+            parallel_overridden: false,
+            ca_cert: None,
+            ca_cert_overridden: false,
         };
         config.config_path = match home_dir() {
             Some(path) => path
@@ -82,13 +116,38 @@ impl ContextBuilder {
         self
     }
 
+    pub(crate) fn ignore_ssl_overridden(mut self, overridden: bool) -> Self {
+        self.config.ignore_ssl_overridden = overridden;
+        self
+    }
+
     pub(crate) fn timeout(mut self, timeout: Duration) -> Self {
         self.config.timeout = timeout;
         self
     }
 
+    pub(crate) fn timeout_overridden(mut self, overridden: bool) -> Self {
+        self.config.timeout_overridden = overridden;
+        self
+    }
+
     pub(crate) fn parallel(mut self, parallel: usize) -> Self {
         self.config.parallel = parallel;
+        self
+    }
+
+    pub(crate) fn parallel_overridden(mut self, overridden: bool) -> Self {
+        self.config.parallel_overridden = overridden;
+        self
+    }
+
+    pub(crate) fn ca_cert(mut self, ca_cert: Option<String>) -> Self {
+        self.config.ca_cert = ca_cert;
+        self
+    }
+
+    pub(crate) fn ca_cert_overridden(mut self, overridden: bool) -> Self {
+        self.config.ca_cert_overridden = overridden;
         self
     }
 
@@ -158,6 +217,10 @@ pub(crate) mod tests {
             Alias {
                 url: url::Url::parse("https://default.store").unwrap(),
                 token: "test_token".to_string(),
+                ignore_ssl: false,
+                timeout: DEFAULT_TIMEOUT_SECS,
+                parallel: DEFAULT_PARALLEL,
+                ca_cert: None,
             },
         );
         config.aliases.insert(
@@ -165,6 +228,10 @@ pub(crate) mod tests {
             Alias {
                 url: url::Url::parse("http://localhost:8383").unwrap(),
                 token: current_token,
+                ignore_ssl: false,
+                timeout: DEFAULT_TIMEOUT_SECS,
+                parallel: DEFAULT_PARALLEL,
+                ca_cert: None,
             },
         );
         config_file.save().unwrap();

--- a/src/io/reduct.rs
+++ b/src/io/reduct.rs
@@ -17,17 +17,17 @@ pub(crate) async fn build_client(
     let (url, token) = parse_url_and_token(ctx, alias_or_url)?;
     let options = resolve_connection_options(ctx, alias_or_url);
 
-    if let Some(ca_cert) = &options.ca_cert {
-        // reqwest reads SSL_CERT_FILE from the process environment.
-        std::env::set_var("SSL_CERT_FILE", ca_cert);
-    }
-
-    let client = ReductClient::builder()
+    let mut client = ReductClient::builder()
         .url(url.as_str())
         .api_token(token.as_str())
         .verify_ssl(!options.ignore_ssl)
-        .timeout(options.timeout)
-        .try_build()?;
+        .timeout(options.timeout);
+
+    if let Some(ca_cert) = &options.ca_cert {
+        client = client.ca_cert_path(ca_cert);
+    }
+
+    let client = client.try_build()?;
     Ok(client)
 }
 

--- a/src/io/reduct.rs
+++ b/src/io/reduct.rs
@@ -3,7 +3,7 @@
 //    License, v. 2.0. If a copy of the MPL was not distributed with this
 //    file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::config::find_alias;
+use crate::config::{find_alias, resolve_connection_options};
 use crate::context::CliContext;
 use anyhow::anyhow;
 use reduct_rs::ReductClient;
@@ -14,16 +14,19 @@ pub(crate) async fn build_client(
     ctx: &CliContext,
     alias_or_url: &str,
 ) -> anyhow::Result<ReductClient> {
-    let (url, token) = match parse_url_and_token(ctx, alias_or_url) {
-        Ok(value) => value,
-        Err(err) => return Err(err),
-    };
+    let (url, token) = parse_url_and_token(ctx, alias_or_url)?;
+    let options = resolve_connection_options(ctx, alias_or_url);
+
+    if let Some(ca_cert) = &options.ca_cert {
+        // reqwest reads SSL_CERT_FILE from the process environment.
+        std::env::set_var("SSL_CERT_FILE", ca_cert);
+    }
 
     let client = ReductClient::builder()
         .url(url.as_str())
         .api_token(token.as_str())
-        .verify_ssl(!ctx.ignore_ssl())
-        .timeout(ctx.timeout())
+        .verify_ssl(!options.ignore_ssl)
+        .timeout(options.timeout)
         .try_build()?;
     Ok(client)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,6 @@ use crate::cmd::replica::{replication_cmd, replication_handler};
 use crate::cmd::rm::{rm_cmd, rm_handler};
 use crate::cmd::server::{server_cmd, server_handler};
 use crate::cmd::token::{token_cmd, token_handler};
-use clap::parser::ValueSource;
 use clap::ArgAction::SetTrue;
 use clap::{crate_description, crate_name, crate_version, value_parser, Arg, Command};
 use colored::Colorize;
@@ -55,7 +54,6 @@ fn cli() -> Command {
                 .value_name("SECONDS")
                 .help("Timeout for requests")
                 .value_parser(value_parser!(u64))
-                .default_value("30")
                 .required(false)
                 .global(true),
         )
@@ -66,7 +64,6 @@ fn cli() -> Command {
                 .value_name("COUNT")
                 .help("Number of parallel requests")
                 .value_parser(value_parser!(usize))
-                .default_value("10")
                 .required(false)
                 .global(true),
         )
@@ -83,20 +80,16 @@ fn cli() -> Command {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let matches = cli().get_matches();
-    let ignore_ssl = matches.get_flag("ignore-ssl");
-    let timeout = *matches.get_one::<u64>("timeout").unwrap();
-    let parallel = *matches.get_one::<usize>("parallel").unwrap();
+    let ignore_ssl = matches.get_flag("ignore-ssl").then_some(true);
+    let timeout = matches.get_one::<u64>("timeout").copied();
+    let parallel = matches.get_one::<usize>("parallel").copied();
     let ca_cert = matches.get_one::<String>("ca-cert").cloned();
 
     let ctx = ContextBuilder::new()
         .ignore_ssl(ignore_ssl)
-        .ignore_ssl_overridden(ignore_ssl)
-        .timeout(Duration::from_secs(timeout))
-        .timeout_overridden(matches.value_source("timeout") == Some(ValueSource::CommandLine))
+        .timeout(timeout.map(Duration::from_secs))
         .parallel(parallel)
-        .parallel_overridden(matches.value_source("parallel") == Some(ValueSource::CommandLine))
         .ca_cert(ca_cert)
-        .ca_cert_overridden(matches.value_source("ca-cert") == Some(ValueSource::CommandLine))
         .build();
 
     let result = match matches.subcommand() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ use crate::cmd::replica::{replication_cmd, replication_handler};
 use crate::cmd::rm::{rm_cmd, rm_handler};
 use crate::cmd::server::{server_cmd, server_handler};
 use crate::cmd::token::{token_cmd, token_handler};
+use clap::parser::ValueSource;
 use clap::ArgAction::SetTrue;
 use clap::{crate_description, crate_name, crate_version, value_parser, Arg, Command};
 use colored::Colorize;
@@ -37,6 +38,14 @@ fn cli() -> Command {
                 .help("Ignore SSL certificate verification")
                 .required(false)
                 .action(SetTrue)
+                .global(true),
+        )
+        .arg(
+            Arg::new("ca-cert")
+                .long("ca-cert")
+                .value_name("PATH")
+                .help("Path to a custom CA certificate bundle/file")
+                .required(false)
                 .global(true),
         )
         .arg(
@@ -74,12 +83,20 @@ fn cli() -> Command {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let matches = cli().get_matches();
+    let ignore_ssl = matches.get_flag("ignore-ssl");
+    let timeout = *matches.get_one::<u64>("timeout").unwrap();
+    let parallel = *matches.get_one::<usize>("parallel").unwrap();
+    let ca_cert = matches.get_one::<String>("ca-cert").cloned();
+
     let ctx = ContextBuilder::new()
-        .ignore_ssl(matches.get_flag("ignore-ssl"))
-        .timeout(Duration::from_secs(
-            *matches.get_one::<u64>("timeout").unwrap(),
-        ))
-        .parallel(*matches.get_one::<usize>("parallel").unwrap())
+        .ignore_ssl(ignore_ssl)
+        .ignore_ssl_overridden(ignore_ssl)
+        .timeout(Duration::from_secs(timeout))
+        .timeout_overridden(matches.value_source("timeout") == Some(ValueSource::CommandLine))
+        .parallel(parallel)
+        .parallel_overridden(matches.value_source("parallel") == Some(ValueSource::CommandLine))
+        .ca_cert(ca_cert)
+        .ca_cert_overridden(matches.value_source("ca-cert") == Some(ValueSource::CommandLine))
         .build();
 
     let result = match matches.subcommand() {

--- a/src/parse/helpers.rs
+++ b/src/parse/helpers.rs
@@ -3,6 +3,7 @@
 //    License, v. 2.0. If a copy of the MPL was not distributed with this
 //    file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::config::{resolve_connection_options, ConnectionOptions};
 use crate::context::CliContext;
 use chrono::DateTime;
 use clap::parser::MatchesError;
@@ -93,6 +94,7 @@ impl Default for QueryParams {
 pub(crate) fn parse_query_params(
     ctx: &CliContext,
     args: &ArgMatches,
+    alias_or_url: Option<&str>,
 ) -> anyhow::Result<QueryParams> {
     let start = parse_time(args.get_one::<String>("start"))?;
     let stop = parse_time(args.get_one::<String>("stop"))?;
@@ -147,6 +149,16 @@ pub(crate) fn parse_query_params(
         None => None,
     };
 
+    let options = alias_or_url.map_or_else(
+        || ConnectionOptions {
+            ignore_ssl: ctx.ignore_ssl(),
+            timeout: ctx.timeout(),
+            parallel: ctx.parallel(),
+            ca_cert: ctx.ca_cert().cloned(),
+        },
+        |endpoint| resolve_connection_options(ctx, endpoint),
+    );
+
     Ok(QueryParams {
         start,
         stop,
@@ -154,8 +166,8 @@ pub(crate) fn parse_query_params(
         each_s,
         limit,
         entry_filter: entries_filter,
-        parallel: ctx.parallel(),
-        ttl: ctx.timeout() * ctx.parallel() as u32,
+        parallel: options.parallel,
+        ttl: options.timeout * options.parallel as u32,
         when: json_when,
         strict: *strict,
         ext: ext_json,
@@ -168,6 +180,7 @@ mod test {
     use super::*;
     mod parse_query_params {
         use crate::cmd::cp::cp_cmd;
+        use crate::config::ConfigFile;
         use crate::context::tests::context;
         use rstest::rstest;
 
@@ -178,7 +191,7 @@ mod test {
             let args = cp_cmd()
                 .try_get_matches_from(vec!["cp", "serv/buck1", "serv/buck2"])
                 .unwrap();
-            let query_params = parse_query_params(&context, &args).unwrap();
+            let query_params = parse_query_params(&context, &args, None).unwrap();
 
             assert_eq!(query_params.start, None);
             assert_eq!(query_params.stop, None);
@@ -197,7 +210,7 @@ mod test {
                     "200",
                 ])
                 .unwrap();
-            let query_params = parse_query_params(&context, &args).unwrap();
+            let query_params = parse_query_params(&context, &args, None).unwrap();
 
             assert_eq!(query_params.start, Some(100));
             assert_eq!(query_params.stop, Some(200));
@@ -216,7 +229,7 @@ mod test {
                     "2023-01-02T00:00:00Z",
                 ])
                 .unwrap();
-            let query_params = parse_query_params(&context, &args).unwrap();
+            let query_params = parse_query_params(&context, &args, None).unwrap();
 
             assert_eq!(query_params.start, Some(1672531200000000));
             assert_eq!(query_params.stop, Some(1672617600000000));
@@ -227,7 +240,7 @@ mod test {
             let args = cp_cmd()
                 .try_get_matches_from(vec!["cp", "serv/buck1", "serv/buck2", "--each-n", "10"])
                 .unwrap();
-            let query_params = parse_query_params(&context, &args).unwrap();
+            let query_params = parse_query_params(&context, &args, None).unwrap();
 
             assert_eq!(query_params.each_n, Some(10));
         }
@@ -237,7 +250,7 @@ mod test {
             let args = cp_cmd()
                 .try_get_matches_from(vec!["cp", "serv/buck1", "serv/buck2", "--each-s", "10"])
                 .unwrap();
-            let query_params = parse_query_params(&context, &args).unwrap();
+            let query_params = parse_query_params(&context, &args, None).unwrap();
 
             assert_eq!(query_params.each_s, Some(10.0));
         }
@@ -247,7 +260,7 @@ mod test {
             let args = cp_cmd()
                 .try_get_matches_from(vec!["cp", "serv/buck1", "serv/buck2", "--limit", "100"])
                 .unwrap();
-            let query_params = parse_query_params(&context, &args).unwrap();
+            let query_params = parse_query_params(&context, &args, None).unwrap();
 
             assert_eq!(query_params.limit, Some(100));
         }
@@ -264,7 +277,7 @@ mod test {
                     "entry-2",
                 ])
                 .unwrap();
-            let query_params = parse_query_params(&context, &args).unwrap();
+            let query_params = parse_query_params(&context, &args, None).unwrap();
 
             assert_eq!(
                 query_params.entry_filter,
@@ -283,7 +296,7 @@ mod test {
                     r#"{"$gt": 100}"#,
                 ])
                 .unwrap();
-            let query_params = parse_query_params(&context, &args).unwrap();
+            let query_params = parse_query_params(&context, &args, None).unwrap();
 
             assert_eq!(query_params.when, Some(serde_json::json!({"$gt": 100})));
         }
@@ -299,7 +312,7 @@ mod test {
                     r#"{"$gt": 100"#,
                 ])
                 .unwrap();
-            let query_params = parse_query_params(&context, &args);
+            let query_params = parse_query_params(&context, &args, None);
 
             assert!(query_params
                 .err()
@@ -313,9 +326,26 @@ mod test {
             let args = cp_cmd()
                 .try_get_matches_from(vec!["cp", "serv/buck1", "serv/buck2", "--strict"])
                 .unwrap();
-            let query_params = parse_query_params(&context, &args).unwrap();
+            let query_params = parse_query_params(&context, &args, None).unwrap();
 
             assert_eq!(query_params.strict, true);
+        }
+
+        #[rstest]
+        fn parse_with_alias_defaults(context: CliContext) {
+            let mut config_file = ConfigFile::load(context.config_path()).unwrap();
+            let alias = config_file.mut_config().aliases.get_mut("default").unwrap();
+            alias.timeout = 12;
+            alias.parallel = 3;
+            config_file.save().unwrap();
+
+            let args = cp_cmd()
+                .try_get_matches_from(vec!["cp", "default/buck1", "default/buck2"])
+                .unwrap();
+            let query_params = parse_query_params(&context, &args, Some("default")).unwrap();
+
+            assert_eq!(query_params.parallel, 3);
+            assert_eq!(query_params.ttl, Duration::from_secs(36));
         }
     }
 }

--- a/src/parse/helpers.rs
+++ b/src/parse/helpers.rs
@@ -151,9 +151,9 @@ pub(crate) fn parse_query_params(
 
     let options = alias_or_url.map_or_else(
         || ConnectionOptions {
-            ignore_ssl: ctx.ignore_ssl(),
-            timeout: ctx.timeout(),
-            parallel: ctx.parallel(),
+            ignore_ssl: ctx.ignore_ssl().unwrap_or(false),
+            timeout: ctx.timeout().unwrap_or(crate::context::DEFAULT_TIMEOUT),
+            parallel: ctx.parallel().unwrap_or(crate::context::DEFAULT_PARALLEL),
             ca_cert: ctx.ca_cert().cloned(),
         },
         |endpoint| resolve_connection_options(ctx, endpoint),


### PR DESCRIPTION
Closes #188

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

- Add global `--ca-cert` support and thread it through `CliContext` into `ReductClientBuilder`.
- Persist alias connection defaults from `alias add`, including `--ca-cert`, `--ignore-ssl`, `--timeout`, and `--parallel`.
- Resolve per-alias connection options when building clients and when deriving query TTL/parallelism for `cp` and `rm`.
- Update `reduct-rs` to `1.19.0` from the `main` branch and refresh the lockfile.
- Add tests covering alias persistence and alias-based connection option resolution.

### Related issues

- #188

### Does this PR introduce a breaking change?

No.

### Other information:

Validation performed:
- `cargo check`
- `cargo test` currently fails without a local ReductStore listening on `http://localhost:8383`; 96 tests passed and 53 integration-style tests failed with `ConnectionError`
