### PR TITLE
Fix cp attachment copying in bucket-to-bucket transfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Copy entry attachments during bucket-to-bucket `cp` transfers so metadata is preserved, [PR-196](https://github.com/reductstore/reduct-cli/pull/196)
 - Fix `cp` progress estimation to use time windows with `--start/--stop` and use record-count mode when a limit is set via `--limit` or `--when` (`$limit`), [PR-184](https://github.com/reductstore/reduct-cli/pull/184)
 
 ## 0.10.2 - 2026-02-16

--- a/src/cmd/cp/b2b.rs
+++ b/src/cmd/cp/b2b.rs
@@ -11,47 +11,16 @@ use crate::parse::parse_query_params;
 use clap::ArgMatches;
 use reduct_rs::{Bucket, ErrorCode, Record, ReductError};
 use serde_json::Value;
-use std::collections::{BTreeMap, HashMap, HashSet};
-use std::sync::{Arc, Mutex};
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
 
 struct CopyToBucketVisitor {
-    src_bucket: Arc<Bucket>,
     dst_bucket: Arc<Bucket>,
-    attachments_copied: Arc<Mutex<HashSet<String>>>,
-}
-
-impl CopyToBucketVisitor {
-    async fn copy_attachments_once(&self, entry_name: &str) -> Result<(), ReductError> {
-        {
-            let copied_entries = self.attachments_copied.lock().unwrap();
-            if copied_entries.contains(entry_name) {
-                return Ok(());
-            }
-        }
-
-        let attachments = match self.src_bucket.read_attachments(entry_name).await {
-            Ok(attachments) => attachments,
-            Err(err) if err.status() == ErrorCode::NotFound => HashMap::<String, Value>::new(),
-            Err(err) => return Err(err),
-        };
-
-        if !attachments.is_empty() {
-            self.dst_bucket
-                .write_attachments(entry_name, attachments)
-                .await?;
-        }
-
-        self.attachments_copied
-            .lock()
-            .unwrap()
-            .insert(entry_name.to_string());
-        Ok(())
-    }
 }
 
 #[async_trait::async_trait]
 impl CopyVisitor for CopyToBucketVisitor {
-    async fn visit(
+    async fn copy_records(
         &self,
         entry_name: &str,
         mut records: Vec<Record>,
@@ -76,10 +45,6 @@ impl CopyVisitor for CopyToBucketVisitor {
                 }
             }
 
-            if result.is_empty() {
-                self.copy_attachments_once(entry_name).await?;
-            }
-
             Ok(result)
         } else {
             let errors = self
@@ -93,12 +58,26 @@ impl CopyVisitor for CopyToBucketVisitor {
                 .filter(|(_, err)| err.status() != ErrorCode::Conflict)
                 .collect();
 
-            if errors.is_empty() {
-                self.copy_attachments_once(entry_name).await?;
-            }
-
             Ok(errors)
         }
+    }
+
+    fn supports_attachments(&self) -> bool {
+        true
+    }
+
+    async fn copy_attachments(
+        &self,
+        entry_name: &str,
+        attachments: HashMap<String, Value>,
+    ) -> Result<(), ReductError> {
+        if attachments.is_empty() {
+            return Ok(());
+        }
+
+        self.dst_bucket
+            .write_attachments(entry_name, attachments)
+            .await
     }
 }
 
@@ -153,30 +132,14 @@ pub(crate) async fn cp_bucket_to_bucket_with(
         }
     };
 
-    // Bucket handles are not Clone, so obtain dedicated handles for the visitor.
-    let src_bucket_visitor = Arc::new(
-        build_client(ctx, src_instance)
-            .await?
-            .get_bucket(src_bucket_name)
-            .await?,
-    );
-    let dst_bucket_visitor_ref = Arc::new(
-        build_client(ctx, dst_instance)
-            .await?
-            .get_bucket(dst_bucket.name())
-            .await?,
-    );
-
-    let dst_bucket_visitor = CopyToBucketVisitor {
-        src_bucket: Arc::clone(&src_bucket_visitor),
-        dst_bucket: Arc::clone(&dst_bucket_visitor_ref),
-        attachments_copied: Arc::new(Mutex::new(HashSet::new())),
-    };
-
     let entry_start_overrides = if from_last {
-        Some(build_entry_start_overrides(dst_bucket_visitor.dst_bucket.as_ref()).await?)
+        Some(build_entry_start_overrides(&dst_bucket).await?)
     } else {
         None
+    };
+
+    let dst_bucket_visitor = CopyToBucketVisitor {
+        dst_bucket: Arc::new(dst_bucket),
     };
 
     start_loading_with_entry_start_overrides(
@@ -229,7 +192,11 @@ mod tests {
 
         #[rstest]
         #[tokio::test]
-        async fn test_visit(context: CliContext, #[future] bucket: String, records: Vec<Record>) {
+        async fn test_copy_records(
+            context: CliContext,
+            #[future] bucket: String,
+            records: Vec<Record>,
+        ) {
             let client = build_client(&context, "local").await.unwrap();
             let dst_bucket_name = bucket.await;
             let src_bucket_name = format!("{}-src", dst_bucket_name);
@@ -239,7 +206,7 @@ mod tests {
                 .send()
                 .await
                 .unwrap();
-            let src_bucket = client
+            let _src_bucket = client
                 .create_bucket(&src_bucket_name)
                 .exist_ok(true)
                 .send()
@@ -247,15 +214,12 @@ mod tests {
                 .unwrap();
 
             let dst_bucket = Arc::new(dst_bucket);
-            let src_bucket = Arc::new(src_bucket);
             let visitor = CopyToBucketVisitor {
-                src_bucket: Arc::clone(&src_bucket),
                 dst_bucket: Arc::clone(&dst_bucket),
-                attachments_copied: Arc::new(Mutex::new(HashSet::new())),
             };
 
             // should write the record to the destination bucket
-            visitor.visit("test", records).await.unwrap();
+            visitor.copy_records("test", records).await.unwrap();
 
             let record = dst_bucket
                 .read_record("test")
@@ -270,7 +234,7 @@ mod tests {
 
         #[rstest]
         #[tokio::test]
-        async fn test_visit_with_batch(
+        async fn test_copy_records_with_batch(
             context: CliContext,
             #[future] bucket: String,
             batch_records: Vec<Record>,
@@ -284,7 +248,7 @@ mod tests {
                 .send()
                 .await
                 .unwrap();
-            let src_bucket = client
+            let _src_bucket = client
                 .create_bucket(&src_bucket_name)
                 .exist_ok(true)
                 .send()
@@ -292,15 +256,15 @@ mod tests {
                 .unwrap();
 
             let dst_bucket = Arc::new(dst_bucket);
-            let src_bucket = Arc::new(src_bucket);
             let visitor = CopyToBucketVisitor {
-                src_bucket: Arc::clone(&src_bucket),
                 dst_bucket: Arc::clone(&dst_bucket),
-                attachments_copied: Arc::new(Mutex::new(HashSet::new())),
             };
 
             // should write the record to the destination bucket
-            visitor.visit("batch_test", batch_records).await.unwrap();
+            visitor
+                .copy_records("batch_test", batch_records)
+                .await
+                .unwrap();
 
             let record = dst_bucket
                 .read_record("batch_test")

--- a/src/cmd/cp/b2b.rs
+++ b/src/cmd/cp/b2b.rs
@@ -121,9 +121,9 @@ pub(crate) async fn cp_bucket_to_bucket_with(
     ctx: &CliContext,
     args: &ArgMatches,
     src_instance: &str,
-    src_bucket: &str,
+    src_bucket_name: &str,
     dst_instance: &str,
-    dst_bucket: &str,
+    dst_bucket_name: &str,
 ) -> anyhow::Result<()> {
     let query_params = parse_query_params(ctx, &args, Some(src_instance))?;
     let from_last = args.get_flag("from-last");
@@ -133,17 +133,17 @@ pub(crate) async fn cp_bucket_to_bucket_with(
 
     let src_bucket = build_client(ctx, src_instance)
         .await?
-        .get_bucket(src_bucket)
+        .get_bucket(src_bucket_name)
         .await?;
 
     let dst_client = build_client(ctx, dst_instance).await?;
-    let dst_bucket = match dst_client.get_bucket(dst_bucket).await {
+    let dst_bucket = match dst_client.get_bucket(dst_bucket_name).await {
         Ok(bucket) => bucket,
         Err(err) => {
             if err.status() == ErrorCode::NotFound {
                 // Create the bucket if it does not exist with the same settings as the source bucket
                 dst_client
-                    .create_bucket(dst_bucket)
+                    .create_bucket(dst_bucket_name)
                     .settings(src_bucket.settings().await?)
                     .send()
                     .await?
@@ -153,8 +153,19 @@ pub(crate) async fn cp_bucket_to_bucket_with(
         }
     };
 
-    let src_bucket_visitor = Arc::new(src_bucket.clone());
-    let dst_bucket_visitor_ref = Arc::new(dst_bucket.clone());
+    // Bucket handles are not Clone, so obtain dedicated handles for the visitor.
+    let src_bucket_visitor = Arc::new(
+        build_client(ctx, src_instance)
+            .await?
+            .get_bucket(src_bucket_name)
+            .await?,
+    );
+    let dst_bucket_visitor_ref = Arc::new(
+        build_client(ctx, dst_instance)
+            .await?
+            .get_bucket(dst_bucket.name())
+            .await?,
+    );
 
     let dst_bucket_visitor = CopyToBucketVisitor {
         src_bucket: Arc::clone(&src_bucket_visitor),
@@ -396,6 +407,59 @@ mod tests {
             assert_eq!(
                 attachments.get("schema"),
                 Some(&serde_json::json!({"type":"object"}))
+            );
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_cp_bucket_to_bucket_copies_attachments_for_batch(
+            context: CliContext,
+            #[future] bucket: String,
+            #[future] bucket2: String,
+        ) {
+            let client = build_client(&context, "local").await.unwrap();
+            let src_bucket = client.create_bucket(&bucket.await).send().await.unwrap();
+            let dst_bucket = client.create_bucket(&bucket2.await).send().await.unwrap();
+
+            src_bucket
+                .write_record("test")
+                .timestamp_us(123456)
+                .data(Bytes::from_static(b"test-1"))
+                .send()
+                .await
+                .unwrap();
+            src_bucket
+                .write_record("test")
+                .timestamp_us(123457)
+                .data(Bytes::from_static(b"test-2"))
+                .send()
+                .await
+                .unwrap();
+            src_bucket
+                .write_attachments(
+                    "test",
+                    HashMap::from([(
+                        "schema".to_string(),
+                        serde_json::json!({"type":"object","version":1}),
+                    )]),
+                )
+                .await
+                .unwrap();
+
+            let args = cp_cmd()
+                .try_get_matches_from(vec![
+                    "cp",
+                    format!("local/{}", src_bucket.name()).as_str(),
+                    format!("local/{}", dst_bucket.name()).as_str(),
+                ])
+                .unwrap();
+
+            cp_bucket_to_bucket(&context, &args).await.unwrap();
+
+            let attachments = dst_bucket.read_attachments("test").await.unwrap();
+            assert_eq!(
+                attachments.get("schema"),
+                Some(&serde_json::json!({"type":"object","version":1}))
             );
         }
 

--- a/src/cmd/cp/b2b.rs
+++ b/src/cmd/cp/b2b.rs
@@ -62,10 +62,6 @@ impl CopyVisitor for CopyToBucketVisitor {
         }
     }
 
-    fn supports_attachments(&self) -> bool {
-        true
-    }
-
     async fn copy_attachments(
         &self,
         entry_name: &str,

--- a/src/cmd/cp/b2b.rs
+++ b/src/cmd/cp/b2b.rs
@@ -10,11 +10,43 @@ use crate::io::reduct::build_client;
 use crate::parse::parse_query_params;
 use clap::ArgMatches;
 use reduct_rs::{Bucket, ErrorCode, Record, ReductError};
-use std::collections::{BTreeMap, HashMap};
-use std::sync::Arc;
+use serde_json::Value;
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::sync::{Arc, Mutex};
 
 struct CopyToBucketVisitor {
+    src_bucket: Arc<Bucket>,
     dst_bucket: Arc<Bucket>,
+    attachments_copied: Arc<Mutex<HashSet<String>>>,
+}
+
+impl CopyToBucketVisitor {
+    async fn copy_attachments_once(&self, entry_name: &str) -> Result<(), ReductError> {
+        {
+            let copied_entries = self.attachments_copied.lock().unwrap();
+            if copied_entries.contains(entry_name) {
+                return Ok(());
+            }
+        }
+
+        let attachments = match self.src_bucket.read_attachments(entry_name).await {
+            Ok(attachments) => attachments,
+            Err(err) if err.status() == ErrorCode::NotFound => HashMap::<String, Value>::new(),
+            Err(err) => return Err(err),
+        };
+
+        if !attachments.is_empty() {
+            self.dst_bucket
+                .write_attachments(entry_name, attachments)
+                .await?;
+        }
+
+        self.attachments_copied
+            .lock()
+            .unwrap()
+            .insert(entry_name.to_string());
+        Ok(())
+    }
 }
 
 #[async_trait::async_trait]
@@ -43,6 +75,11 @@ impl CopyVisitor for CopyToBucketVisitor {
                     result.insert(timestamp, err);
                 }
             }
+
+            if result.is_empty() {
+                self.copy_attachments_once(entry_name).await?;
+            }
+
             Ok(result)
         } else {
             let errors = self
@@ -51,10 +88,16 @@ impl CopyVisitor for CopyToBucketVisitor {
                 .add_records(records)
                 .send()
                 .await?;
-            Ok(errors
+            let errors: BTreeMap<u64, ReductError> = errors
                 .into_iter()
                 .filter(|(_, err)| err.status() != ErrorCode::Conflict)
-                .collect())
+                .collect();
+
+            if errors.is_empty() {
+                self.copy_attachments_once(entry_name).await?;
+            }
+
+            Ok(errors)
         }
     }
 }
@@ -110,8 +153,13 @@ pub(crate) async fn cp_bucket_to_bucket_with(
         }
     };
 
+    let src_bucket_visitor = Arc::new(src_bucket.clone());
+    let dst_bucket_visitor_ref = Arc::new(dst_bucket.clone());
+
     let dst_bucket_visitor = CopyToBucketVisitor {
-        dst_bucket: Arc::new(dst_bucket),
+        src_bucket: Arc::clone(&src_bucket_visitor),
+        dst_bucket: Arc::clone(&dst_bucket_visitor_ref),
+        attachments_copied: Arc::new(Mutex::new(HashSet::new())),
     };
 
     let entry_start_overrides = if from_last {
@@ -172,16 +220,27 @@ mod tests {
         #[tokio::test]
         async fn test_visit(context: CliContext, #[future] bucket: String, records: Vec<Record>) {
             let client = build_client(&context, "local").await.unwrap();
+            let dst_bucket_name = bucket.await;
+            let src_bucket_name = format!("{}-src", dst_bucket_name);
             let dst_bucket = client
-                .create_bucket(&bucket.await)
+                .create_bucket(&dst_bucket_name)
+                .exist_ok(true)
+                .send()
+                .await
+                .unwrap();
+            let src_bucket = client
+                .create_bucket(&src_bucket_name)
                 .exist_ok(true)
                 .send()
                 .await
                 .unwrap();
 
             let dst_bucket = Arc::new(dst_bucket);
+            let src_bucket = Arc::new(src_bucket);
             let visitor = CopyToBucketVisitor {
+                src_bucket: Arc::clone(&src_bucket),
                 dst_bucket: Arc::clone(&dst_bucket),
+                attachments_copied: Arc::new(Mutex::new(HashSet::new())),
             };
 
             // should write the record to the destination bucket
@@ -206,16 +265,27 @@ mod tests {
             batch_records: Vec<Record>,
         ) {
             let client = build_client(&context, "local").await.unwrap();
+            let dst_bucket_name = bucket.await;
+            let src_bucket_name = format!("{}-src", dst_bucket_name);
             let dst_bucket = client
-                .create_bucket(&bucket.await)
+                .create_bucket(&dst_bucket_name)
+                .exist_ok(true)
+                .send()
+                .await
+                .unwrap();
+            let src_bucket = client
+                .create_bucket(&src_bucket_name)
                 .exist_ok(true)
                 .send()
                 .await
                 .unwrap();
 
             let dst_bucket = Arc::new(dst_bucket);
+            let src_bucket = Arc::new(src_bucket);
             let visitor = CopyToBucketVisitor {
+                src_bucket: Arc::clone(&src_bucket),
                 dst_bucket: Arc::clone(&dst_bucket),
+                attachments_copied: Arc::new(Mutex::new(HashSet::new())),
             };
 
             // should write the record to the destination bucket
@@ -286,6 +356,49 @@ mod tests {
                 .unwrap();
             assert_eq!(record.bytes().await.unwrap(), test_data);
         }
+        #[rstest]
+        #[tokio::test]
+        async fn test_cp_bucket_to_bucket_copies_attachments(
+            context: CliContext,
+            #[future] bucket: String,
+            #[future] bucket2: String,
+        ) {
+            let client = build_client(&context, "local").await.unwrap();
+            let src_bucket = client.create_bucket(&bucket.await).send().await.unwrap();
+            let dst_bucket = client.create_bucket(&bucket2.await).send().await.unwrap();
+
+            src_bucket
+                .write_record("test")
+                .timestamp_us(123456)
+                .data(Bytes::from_static(b"test"))
+                .send()
+                .await
+                .unwrap();
+            src_bucket
+                .write_attachments(
+                    "test",
+                    HashMap::from([("schema".to_string(), serde_json::json!({"type":"object"}))]),
+                )
+                .await
+                .unwrap();
+
+            let args = cp_cmd()
+                .try_get_matches_from(vec![
+                    "cp",
+                    format!("local/{}", src_bucket.name()).as_str(),
+                    format!("local/{}", dst_bucket.name()).as_str(),
+                ])
+                .unwrap();
+
+            cp_bucket_to_bucket(&context, &args).await.unwrap();
+
+            let attachments = dst_bucket.read_attachments("test").await.unwrap();
+            assert_eq!(
+                attachments.get("schema"),
+                Some(&serde_json::json!({"type":"object"}))
+            );
+        }
+
         #[rstest]
         #[tokio::test]
         async fn test_cp_bucket_to_bucket_more_than_80_records(

--- a/src/cmd/cp/b2f.rs
+++ b/src/cmd/cp/b2f.rs
@@ -36,7 +36,7 @@ struct Meta {
 
 #[async_trait::async_trait]
 impl CopyVisitor for CopyToFolderVisitor {
-    async fn visit(
+    async fn copy_records(
         &self,
         entry_name: &str,
         records: Vec<Record>,
@@ -46,7 +46,7 @@ impl CopyVisitor for CopyToFolderVisitor {
         if records.len() == 1 {
             let record = records.into_iter().next().unwrap();
             let timestamp = record.timestamp_us();
-            let res = self.visit_one_record(&entry_name, record).await;
+            let res = self.visit_one_record(entry_name, record).await;
             if let Err(err) = res {
                 result.insert(timestamp, err);
             }
@@ -227,7 +227,7 @@ mod tests {
             entry_name: String,
             records: Vec<Record>,
         ) {
-            let result = visitor.visit(&entry_name, records).await;
+            let result = visitor.copy_records(&entry_name, records).await;
             assert!(result.is_ok());
 
             let file_path = PathBuf::from(visitor.dst_folder)
@@ -247,7 +247,7 @@ mod tests {
             entry_name: String,
             batch_records: Vec<Record>,
         ) {
-            let result = visitor.visit(&entry_name, batch_records).await;
+            let result = visitor.copy_records(&entry_name, batch_records).await;
             assert!(result.is_ok());
 
             let file_path = PathBuf::from(&visitor.dst_folder)
@@ -277,7 +277,7 @@ mod tests {
             records: Vec<Record>,
         ) {
             visitor.ext = Some("md".to_string());
-            let result = visitor.visit(&entry_name, records).await;
+            let result = visitor.copy_records(&entry_name, records).await;
             assert!(result.is_ok());
 
             let file_path = PathBuf::from(visitor.dst_folder)
@@ -294,7 +294,7 @@ mod tests {
             records: Vec<Record>,
         ) {
             visitor.with_meta = true;
-            let result = visitor.visit(&entry_name, records).await;
+            let result = visitor.copy_records(&entry_name, records).await;
             assert!(result.is_ok());
 
             let file_path = PathBuf::from(visitor.dst_folder.clone())

--- a/src/cmd/cp/helpers.rs
+++ b/src/cmd/cp/helpers.rs
@@ -4,7 +4,7 @@
 //    file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 
 use crate::parse::{fetch_and_filter_entries, QueryParams};
@@ -13,6 +13,7 @@ use futures_util::StreamExt;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use reduct_rs::{condition, Bucket, EntryInfo, ErrorCode, QueryBuilder, Record, ReductError};
 use serde_json::Value;
+use tokio::sync::Mutex as AsyncMutex;
 use tokio::task::JoinSet;
 use tokio::time::{sleep, Instant};
 
@@ -304,10 +305,6 @@ pub(super) trait CopyVisitor {
         records: Vec<Record>,
     ) -> Result<BTreeMap<u64, ReductError>, ReductError>;
 
-    fn supports_attachments(&self) -> bool {
-        false
-    }
-
     async fn copy_attachments(
         &self,
         _entry_name: &str,
@@ -358,7 +355,7 @@ where
 
     let dst_bucket = Arc::new(dst_bucket_v);
     let src_bucket = Arc::new(src_bucket);
-    let copied_attachments = Arc::new(Mutex::new(HashSet::new()));
+    let copied_attachments = Arc::new(AsyncMutex::new(HashSet::new()));
     let entry_start_overrides = entry_start_overrides.map(Arc::new);
 
     let display_limit = query_params.parallel.max(1);
@@ -369,7 +366,7 @@ where
         &query_params,
         entry_start_overrides.as_ref().map(|v| v.as_ref()),
     );
-    let bucket_progress = Arc::new(Mutex::new(BucketProgress::new(
+    let bucket_progress = Arc::new(StdMutex::new(BucketProgress::new(
         bucket_name,
         display_limit,
         entries.len(),
@@ -546,8 +543,8 @@ async fn run_entry_copy<V: CopyVisitor + Sync + ?Sized>(
     visitor: Arc<V>,
     semaphore: Arc<tokio::sync::Semaphore>,
     mut params: QueryParams,
-    bucket_progress: Arc<Mutex<BucketProgress>>,
-    copied_attachments: Arc<Mutex<HashSet<String>>>,
+    bucket_progress: Arc<StdMutex<BucketProgress>>,
+    copied_attachments: Arc<AsyncMutex<HashSet<String>>>,
 ) -> EntryCopyOutcome {
     // Copy one entry with retry logic and bounded batching to control memory usage.
     let mut timestamp = params.start.unwrap_or(entry.oldest_record);
@@ -577,20 +574,18 @@ async fn run_entry_copy<V: CopyVisitor + Sync + ?Sized>(
     }
 
     while attempts > 0 {
-        if visitor.supports_attachments() {
-            if let Err(err) = copy_entry_attachments_once(
-                &entry.name,
-                bucket.as_ref(),
-                visitor.as_ref(),
-                copied_attachments.as_ref(),
-            )
-            .await
-            {
-                return EntryCopyOutcome {
-                    entry_name,
-                    result: Err(err),
-                };
-            }
+        if let Err(err) = copy_entry_attachments_once(
+            &entry.name,
+            bucket.as_ref(),
+            visitor.as_ref(),
+            copied_attachments.as_ref(),
+        )
+        .await
+        {
+            return EntryCopyOutcome {
+                entry_name,
+                result: Err(err),
+            };
         }
 
         let query_builder = build_query(&bucket, &entry, &params);
@@ -695,10 +690,10 @@ async fn copy_entry_attachments_once<V: CopyVisitor + Sync + ?Sized>(
     entry_name: &str,
     src_bucket: &Bucket,
     visitor: &V,
-    copied_attachments: &Mutex<HashSet<String>>,
+    copied_attachments: &AsyncMutex<HashSet<String>>,
 ) -> Result<(), ReductError> {
     {
-        let copied = copied_attachments.lock().unwrap();
+        let copied = copied_attachments.lock().await;
         if copied.contains(entry_name) {
             return Ok(());
         }
@@ -714,7 +709,7 @@ async fn copy_entry_attachments_once<V: CopyVisitor + Sync + ?Sized>(
 
     copied_attachments
         .lock()
-        .unwrap()
+        .await
         .insert(entry_name.to_string());
 
     Ok(())
@@ -724,7 +719,7 @@ async fn flush_batch<V: CopyVisitor + Sync + ?Sized>(
     entry_name: &str,
     batch: &mut Vec<Record>,
     visitor: &V,
-    bucket_progress: &Arc<Mutex<BucketProgress>>,
+    bucket_progress: &Arc<StdMutex<BucketProgress>>,
     attempts: &mut u8,
     timestamp: &mut u64,
     record_count: &mut u64,
@@ -761,7 +756,7 @@ async fn flush_batch<V: CopyVisitor + Sync + ?Sized>(
 // we also need to adjust the limit if we have one
 async fn make_attempt(
     attempts: &mut u8,
-    bucket_progress: &Arc<Mutex<BucketProgress>>,
+    bucket_progress: &Arc<StdMutex<BucketProgress>>,
     params: &mut QueryParams,
     record_count: u64,
     timestamp: u64,

--- a/src/cmd/cp/helpers.rs
+++ b/src/cmd/cp/helpers.rs
@@ -3,7 +3,7 @@
 //    License, v. 2.0. If a copy of the MPL was not distributed with this
 //    file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -11,7 +11,8 @@ use crate::parse::{fetch_and_filter_entries, QueryParams};
 use bytesize::ByteSize;
 use futures_util::StreamExt;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
-use reduct_rs::{condition, Bucket, EntryInfo, QueryBuilder, Record, ReductError};
+use reduct_rs::{condition, Bucket, EntryInfo, ErrorCode, QueryBuilder, Record, ReductError};
+use serde_json::Value;
 use tokio::task::JoinSet;
 use tokio::time::{sleep, Instant};
 
@@ -297,11 +298,23 @@ fn build_query(src_bucket: &Bucket, entry: &EntryInfo, query_params: &QueryParam
 
 #[async_trait::async_trait]
 pub(super) trait CopyVisitor {
-    async fn visit(
+    async fn copy_records(
         &self,
         entry_name: &str,
         records: Vec<Record>,
     ) -> Result<BTreeMap<u64, ReductError>, ReductError>;
+
+    fn supports_attachments(&self) -> bool {
+        false
+    }
+
+    async fn copy_attachments(
+        &self,
+        _entry_name: &str,
+        _attachments: HashMap<String, Value>,
+    ) -> Result<(), ReductError> {
+        Ok(())
+    }
 }
 
 /**
@@ -345,6 +358,7 @@ where
 
     let dst_bucket = Arc::new(dst_bucket_v);
     let src_bucket = Arc::new(src_bucket);
+    let copied_attachments = Arc::new(Mutex::new(HashSet::new()));
     let entry_start_overrides = entry_start_overrides.map(Arc::new);
 
     let display_limit = query_params.parallel.max(1);
@@ -377,6 +391,7 @@ where
             local_sem,
             params,
             bucket_progress,
+            Arc::clone(&copied_attachments),
         ));
     }
 
@@ -525,13 +540,14 @@ struct EntryCopyOutcome {
     result: Result<(), ReductError>,
 }
 
-async fn run_entry_copy<V: CopyVisitor + ?Sized>(
+async fn run_entry_copy<V: CopyVisitor + Sync + ?Sized>(
     entry: EntryInfo,
     bucket: Arc<Bucket>,
     visitor: Arc<V>,
     semaphore: Arc<tokio::sync::Semaphore>,
     mut params: QueryParams,
     bucket_progress: Arc<Mutex<BucketProgress>>,
+    copied_attachments: Arc<Mutex<HashSet<String>>>,
 ) -> EntryCopyOutcome {
     // Copy one entry with retry logic and bounded batching to control memory usage.
     let mut timestamp = params.start.unwrap_or(entry.oldest_record);
@@ -561,6 +577,22 @@ async fn run_entry_copy<V: CopyVisitor + ?Sized>(
     }
 
     while attempts > 0 {
+        if visitor.supports_attachments() {
+            if let Err(err) = copy_entry_attachments_once(
+                &entry.name,
+                bucket.as_ref(),
+                visitor.as_ref(),
+                copied_attachments.as_ref(),
+            )
+            .await
+            {
+                return EntryCopyOutcome {
+                    entry_name,
+                    result: Err(err),
+                };
+            }
+        }
+
         let query_builder = build_query(&bucket, &entry, &params);
 
         let _permit = semaphore.acquire().await.unwrap();
@@ -659,7 +691,36 @@ async fn run_entry_copy<V: CopyVisitor + ?Sized>(
     }
 }
 
-async fn flush_batch<V: CopyVisitor + ?Sized>(
+async fn copy_entry_attachments_once<V: CopyVisitor + Sync + ?Sized>(
+    entry_name: &str,
+    src_bucket: &Bucket,
+    visitor: &V,
+    copied_attachments: &Mutex<HashSet<String>>,
+) -> Result<(), ReductError> {
+    {
+        let copied = copied_attachments.lock().unwrap();
+        if copied.contains(entry_name) {
+            return Ok(());
+        }
+    }
+
+    let attachments = match src_bucket.read_attachments(entry_name).await {
+        Ok(attachments) => attachments,
+        Err(err) if err.status() == ErrorCode::NotFound => HashMap::<String, Value>::new(),
+        Err(err) => return Err(err),
+    };
+
+    visitor.copy_attachments(entry_name, attachments).await?;
+
+    copied_attachments
+        .lock()
+        .unwrap()
+        .insert(entry_name.to_string());
+
+    Ok(())
+}
+
+async fn flush_batch<V: CopyVisitor + Sync + ?Sized>(
     entry_name: &str,
     batch: &mut Vec<Record>,
     visitor: &V,
@@ -677,7 +738,7 @@ async fn flush_batch<V: CopyVisitor + ?Sized>(
         .map(|record| (record.timestamp_us(), record.content_length() as u64))
         .collect::<Vec<_>>();
     let taken_records = std::mem::take(batch);
-    let errors = visitor.visit(entry_name, taken_records).await?;
+    let errors = visitor.copy_records(entry_name, taken_records).await?;
     if let Some((_, err)) = errors.into_iter().next() {
         return Err(err);
     }
@@ -904,7 +965,7 @@ mod tests {
             pub Visitor {}
             #[async_trait]
             impl CopyVisitor for Visitor {
-                async fn visit(&self, entry_name: &str, records: Vec<Record>)  -> Result<BTreeMap<u64, ReductError>, ReductError>;
+                async fn copy_records(&self, entry_name: &str, records: Vec<Record>)  -> Result<BTreeMap<u64, ReductError>, ReductError>;
             }
         }
         #[fixture]
@@ -937,7 +998,7 @@ mod tests {
         async fn test_downloading(#[future] src_bucket: Bucket, mut visitor: MockVisitor) {
             let src_bucket = src_bucket.await;
             visitor
-                .expect_visit()
+                .expect_copy_records()
                 .times(2)
                 .return_const(Ok(BTreeMap::new()));
 
@@ -951,17 +1012,17 @@ mod tests {
         async fn test_downloading_metadata(#[future] src_bucket: Bucket, mut visitor: MockVisitor) {
             let src_bucket = src_bucket.await;
             visitor
-                .expect_visit()
+                .expect_copy_records()
                 .withf(|entry, _record| entry == "entry-1")
                 .times(1)
                 .return_const(Ok(BTreeMap::new()));
             visitor
-                .expect_visit()
+                .expect_copy_records()
                 .withf(|entry, _record| entry == "entry-2")
                 .times(1)
                 .return_const(Ok(BTreeMap::new()));
             visitor
-                .expect_visit()
+                .expect_copy_records()
                 .withf(|entry, records| {
                     entry == "entry-3"
                         && records[0].timestamp_us() == 1
@@ -994,12 +1055,12 @@ mod tests {
         ) {
             let src_bucket = src_bucket.await;
             visitor
-                .expect_visit()
+                .expect_copy_records()
                 .withf(|entry, _record| entry == "entry-1")
                 .times(1)
                 .return_const(Err(ReductError::new(ErrorCode::Conflict, "Conflict")));
             visitor
-                .expect_visit()
+                .expect_copy_records()
                 .withf(|entry, _record| entry == "entry-2")
                 .times(1)
                 .return_const(Ok(BTreeMap::new()));
@@ -1016,7 +1077,7 @@ mod tests {
         ) {
             let src_bucket = src_bucket.await;
             visitor
-                .expect_visit()
+                .expect_copy_records()
                 .times(2)
                 .return_const(Ok(BTreeMap::new()));
 
@@ -1037,7 +1098,7 @@ mod tests {
         ) {
             let src_bucket = src_bucket.await;
             visitor
-                .expect_visit()
+                .expect_copy_records()
                 .times(1)
                 .with(eq("entry-1"), always())
                 .return_const(Ok(BTreeMap::new()));
@@ -1056,7 +1117,7 @@ mod tests {
         async fn test_downloading_limit(#[future] src_bucket: Bucket, mut visitor: MockVisitor) {
             let src_bucket = src_bucket.await;
             visitor
-                .expect_visit()
+                .expect_copy_records()
                 .times(2)
                 .return_const(Ok(BTreeMap::new()));
 

--- a/src/cmd/cp/helpers.rs
+++ b/src/cmd/cp/helpers.rs
@@ -4,7 +4,7 @@
 //    file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::sync::{Arc, Mutex as StdMutex};
+use std::sync::Arc;
 use std::time::Duration;
 
 use crate::parse::{fetch_and_filter_entries, QueryParams};
@@ -366,7 +366,7 @@ where
         &query_params,
         entry_start_overrides.as_ref().map(|v| v.as_ref()),
     );
-    let bucket_progress = Arc::new(StdMutex::new(BucketProgress::new(
+    let bucket_progress = Arc::new(AsyncMutex::new(BucketProgress::new(
         bucket_name,
         display_limit,
         entries.len(),
@@ -411,7 +411,7 @@ where
         }
     }
 
-    let progress_guard = bucket_progress.lock().unwrap();
+    let progress_guard = bucket_progress.lock().await;
     if failed_entries == completed_entries {
         progress_guard.all_failed();
         return Err(anyhow::anyhow!(
@@ -543,7 +543,7 @@ async fn run_entry_copy<V: CopyVisitor + Sync + ?Sized>(
     visitor: Arc<V>,
     semaphore: Arc<tokio::sync::Semaphore>,
     mut params: QueryParams,
-    bucket_progress: Arc<StdMutex<BucketProgress>>,
+    bucket_progress: Arc<AsyncMutex<BucketProgress>>,
     copied_attachments: Arc<AsyncMutex<HashSet<String>>>,
 ) -> EntryCopyOutcome {
     // Copy one entry with retry logic and bounded batching to control memory usage.
@@ -719,7 +719,7 @@ async fn flush_batch<V: CopyVisitor + Sync + ?Sized>(
     entry_name: &str,
     batch: &mut Vec<Record>,
     visitor: &V,
-    bucket_progress: &Arc<StdMutex<BucketProgress>>,
+    bucket_progress: &Arc<AsyncMutex<BucketProgress>>,
     attempts: &mut u8,
     timestamp: &mut u64,
     record_count: &mut u64,
@@ -741,7 +741,8 @@ async fn flush_batch<V: CopyVisitor + Sync + ?Sized>(
     for (ts, len) in batch_info {
         *record_count += 1;
         *timestamp = ts;
-        if let Ok(mut progress) = bucket_progress.lock() {
+        {
+            let mut progress = bucket_progress.lock().await;
             progress.update(entry_name, ts, len);
         }
         sleep(Duration::from_micros(5)).await;
@@ -756,7 +757,7 @@ async fn flush_batch<V: CopyVisitor + Sync + ?Sized>(
 // we also need to adjust the limit if we have one
 async fn make_attempt(
     attempts: &mut u8,
-    bucket_progress: &Arc<StdMutex<BucketProgress>>,
+    bucket_progress: &Arc<AsyncMutex<BucketProgress>>,
     params: &mut QueryParams,
     record_count: u64,
     timestamp: u64,
@@ -773,7 +774,8 @@ async fn make_attempt(
             params.limit = Some(limit.saturating_sub(record_count));
         }
 
-        if let Ok(progress) = bucket_progress.lock() {
+        {
+            let progress = bucket_progress.lock().await;
             progress.print_warning(format!(
                 "{}. Retrying... (attempts {} / {})",
                 err, *attempts, DOWNLOAD_ATTEMPTS


### PR DESCRIPTION
Closes #195

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

- Extended `CopyToBucketVisitor` to keep both source and destination buckets so bucket-to-bucket copy can propagate entry attachments.
- Added `copy_attachments_once` to read entry attachments from the source bucket and write them to destination exactly once per entry.
- Wired attachment copy into both single-record and batch copy paths, while preserving existing conflict handling behavior.
- Added a new integration test `test_cp_bucket_to_bucket_copies_attachments` to verify copied entries retain attachments.
- Updated existing visitor tests to initialize the new visitor fields.

### Related issues

- https://github.com/reductstore/reduct-cli/issues/195
- Approved implementation plan: https://github.com/reductstore/reduct-cli/issues/195#issuecomment-4112489861

### Does this PR introduce a breaking change?

No.

### Other information:

- I could not execute the Rust test suite in this environment because the repository uses lockfile v4 while installed Cargo is 1.75.0 (`lock file version 4 requires -Znext-lockfile-bump`).