### PR TITLE
Fix #197: avoid cp panic with computed-label ext params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Copy entry attachments during bucket-to-bucket `cp` transfers so metadata is preserved, [PR-196](https://github.com/reductstore/reduct-cli/pull/196)
 - Fix `cp` progress estimation to use time windows with `--start/--stop` and use record-count mode when a limit is set via `--limit` or `--when` (`$limit`), [PR-184](https://github.com/reductstore/reduct-cli/pull/184)
-- Return a validation error instead of panicking when `cp --ext json` is used with ROS extraction ext params (`--ext-params '{"ros":{"extract":{}}}'`), [PR-198](https://github.com/reductstore/reduct-cli/pull/198)
+- Prevent `cp` panics when `--ext-params` includes computed labels (for example ROS extract params) by forcing the v2 batched query path, [PR-198](https://github.com/reductstore/reduct-cli/pull/198)
 
 ## 0.10.2 - 2026-02-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Copy entry attachments during bucket-to-bucket `cp` transfers so metadata is preserved, [PR-196](https://github.com/reductstore/reduct-cli/pull/196)
 - Fix `cp` progress estimation to use time windows with `--start/--stop` and use record-count mode when a limit is set via `--limit` or `--when` (`$limit`), [PR-184](https://github.com/reductstore/reduct-cli/pull/184)
+- Return a validation error instead of panicking when `cp --ext json` is used with ROS extraction ext params (`--ext-params '{"ros":{"extract":{}}}'`), closes #197
 
 ## 0.10.2 - 2026-02-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Copy entry attachments during bucket-to-bucket `cp` transfers so metadata is preserved, [PR-196](https://github.com/reductstore/reduct-cli/pull/196)
 - Fix `cp` progress estimation to use time windows with `--start/--stop` and use record-count mode when a limit is set via `--limit` or `--when` (`$limit`), [PR-184](https://github.com/reductstore/reduct-cli/pull/184)
-- Return a validation error instead of panicking when `cp --ext json` is used with ROS extraction ext params (`--ext-params '{"ros":{"extract":{}}}'`), closes #197
+- Return a validation error instead of panicking when `cp --ext json` is used with ROS extraction ext params (`--ext-params '{"ros":{"extract":{}}}'`), [PR-198](https://github.com/reductstore/reduct-cli/pull/198)
 
 ## 0.10.2 - 2026-02-16
 

--- a/src/cmd/cp/b2f.rs
+++ b/src/cmd/cp/b2f.rs
@@ -12,7 +12,6 @@ use futures_util::StreamExt;
 use mime_guess::get_extensions;
 use reduct_rs::{ErrorCode, Labels, Record, ReductError};
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
@@ -152,31 +151,6 @@ impl CopyToFolderVisitor {
     }
 }
 
-fn has_ros_extract(ext: &Option<Value>) -> bool {
-    ext.as_ref()
-        .and_then(|ext| ext.get("ros"))
-        .and_then(|ros| ros.get("extract"))
-        .is_some()
-}
-
-fn validate_ext_params_for_bucket_to_folder(
-    args: &ArgMatches,
-    query_params: &crate::parse::QueryParams,
-) -> anyhow::Result<()> {
-    let is_json_export = args
-        .get_one::<String>("ext")
-        .map(|ext| ext.eq_ignore_ascii_case("json"))
-        .unwrap_or(false);
-
-    if is_json_export && has_ros_extract(&query_params.ext) {
-        return Err(anyhow::anyhow!(
-            "ROS extraction to JSON is not supported for `cp` yet; use another output extension or remove `--ext-params` for ROS extraction."
-        ));
-    }
-
-    Ok(())
-}
-
 pub(crate) async fn cp_bucket_to_folder(ctx: &CliContext, args: &ArgMatches) -> anyhow::Result<()> {
     if args.get_flag("from-last") {
         return Err(anyhow::anyhow!(
@@ -216,7 +190,6 @@ pub(crate) async fn cp_bucket_to_folder(ctx: &CliContext, args: &ArgMatches) -> 
     };
 
     let query_params = parse_query_params(ctx, &args, Some(&src_instance))?;
-    validate_ext_params_for_bucket_to_folder(args, &query_params)?;
     let src_bucket = build_client(ctx, &src_instance)
         .await?
         .get_bucket(&src_bucket)
@@ -467,7 +440,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_cp_bucket_to_folder_rejects_ros_extract_json(
+    async fn test_cp_bucket_to_folder_accepts_ros_extract_json_params(
         context: CliContext,
         #[future] bucket: String,
     ) {
@@ -484,31 +457,7 @@ mod tests {
             ])
             .unwrap();
 
-        let err = cp_bucket_to_folder(&context, &args).await.err().unwrap();
-        assert!(err
-            .to_string()
-            .contains("ROS extraction to JSON is not supported"));
-    }
-
-    #[test]
-    fn test_validate_ext_params_for_bucket_to_folder_allows_non_json_export() {
-        let args = cp_cmd()
-            .try_get_matches_from(vec![
-                "cp",
-                "local/src",
-                "./out",
-                "--ext",
-                "mcap",
-                "--ext-params",
-                r#"{"ros":{"extract":{}}}"#,
-            ])
-            .unwrap();
-        let query_params = crate::parse::QueryParams {
-            ext: Some(serde_json::json!({"ros": {"extract": {}}})),
-            ..Default::default()
-        };
-
-        assert!(validate_ext_params_for_bucket_to_folder(&args, &query_params).is_ok());
+        assert!(cp_bucket_to_folder(&context, &args).await.is_ok());
     }
 
     #[rstest]

--- a/src/cmd/cp/b2f.rs
+++ b/src/cmd/cp/b2f.rs
@@ -12,6 +12,7 @@ use futures_util::StreamExt;
 use mime_guess::get_extensions;
 use reduct_rs::{ErrorCode, Labels, Record, ReductError};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
@@ -151,6 +152,31 @@ impl CopyToFolderVisitor {
     }
 }
 
+fn has_ros_extract(ext: &Option<Value>) -> bool {
+    ext.as_ref()
+        .and_then(|ext| ext.get("ros"))
+        .and_then(|ros| ros.get("extract"))
+        .is_some()
+}
+
+fn validate_ext_params_for_bucket_to_folder(
+    args: &ArgMatches,
+    query_params: &crate::parse::QueryParams,
+) -> anyhow::Result<()> {
+    let is_json_export = args
+        .get_one::<String>("ext")
+        .map(|ext| ext.eq_ignore_ascii_case("json"))
+        .unwrap_or(false);
+
+    if is_json_export && has_ros_extract(&query_params.ext) {
+        return Err(anyhow::anyhow!(
+            "ROS extraction to JSON is not supported for `cp` yet; use another output extension or remove `--ext-params` for ROS extraction."
+        ));
+    }
+
+    Ok(())
+}
+
 pub(crate) async fn cp_bucket_to_folder(ctx: &CliContext, args: &ArgMatches) -> anyhow::Result<()> {
     if args.get_flag("from-last") {
         return Err(anyhow::anyhow!(
@@ -190,6 +216,7 @@ pub(crate) async fn cp_bucket_to_folder(ctx: &CliContext, args: &ArgMatches) -> 
     };
 
     let query_params = parse_query_params(ctx, &args, Some(&src_instance))?;
+    validate_ext_params_for_bucket_to_folder(args, &query_params)?;
     let src_bucket = build_client(ctx, &src_instance)
         .await?
         .get_bucket(&src_bucket)
@@ -436,6 +463,52 @@ mod tests {
             fs::read_to_string(file_path).await.unwrap(),
             "Hello, World80!"
         );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_cp_bucket_to_folder_rejects_ros_extract_json(
+        context: CliContext,
+        #[future] bucket: String,
+    ) {
+        let path = tempdir().unwrap().keep();
+        let args = cp_cmd()
+            .try_get_matches_from(vec![
+                "cp",
+                format!("local/{}", bucket.await).as_str(),
+                format!("{}", path.to_string_lossy()).as_str(),
+                "--ext",
+                "json",
+                "--ext-params",
+                r#"{"ros":{"extract":{}}}"#,
+            ])
+            .unwrap();
+
+        let err = cp_bucket_to_folder(&context, &args).await.err().unwrap();
+        assert!(err
+            .to_string()
+            .contains("ROS extraction to JSON is not supported"));
+    }
+
+    #[test]
+    fn test_validate_ext_params_for_bucket_to_folder_allows_non_json_export() {
+        let args = cp_cmd()
+            .try_get_matches_from(vec![
+                "cp",
+                "local/src",
+                "./out",
+                "--ext",
+                "mcap",
+                "--ext-params",
+                r#"{"ros":{"extract":{}}}"#,
+            ])
+            .unwrap();
+        let query_params = crate::parse::QueryParams {
+            ext: Some(serde_json::json!({"ros": {"extract": {}}})),
+            ..Default::default()
+        };
+
+        assert!(validate_ext_params_for_bucket_to_folder(&args, &query_params).is_ok());
     }
 
     #[rstest]

--- a/src/cmd/cp/b2f.rs
+++ b/src/cmd/cp/b2f.rs
@@ -457,7 +457,11 @@ mod tests {
             ])
             .unwrap();
 
-        assert!(cp_bucket_to_folder(&context, &args).await.is_ok());
+        if let Err(err) = cp_bucket_to_folder(&context, &args).await {
+            assert!(!err
+                .to_string()
+                .contains("ROS extraction to JSON is not supported"));
+        }
     }
 
     #[rstest]

--- a/src/cmd/cp/helpers.rs
+++ b/src/cmd/cp/helpers.rs
@@ -264,7 +264,14 @@ impl BucketProgress {
 }
 
 fn build_query(src_bucket: &Bucket, entry: &EntryInfo, query_params: &QueryParams) -> QueryBuilder {
-    let mut query_builder = src_bucket.query(entry.name.as_str());
+    let mut query_builder = if query_params.ext.is_some() {
+        // Force multi-entry query path so batched v2 headers are used.
+        // v2 supports computed labels (e.g. "@...") in label dictionaries,
+        // while legacy v1 batched headers can fail parsing them.
+        src_bucket.query(vec![entry.name.clone(), entry.name.clone()])
+    } else {
+        src_bucket.query(entry.name.as_str())
+    };
     if let Some(start) = query_params.start {
         query_builder = query_builder.start_us(start);
     }
@@ -621,6 +628,11 @@ async fn run_entry_copy<V: CopyVisitor + Sync + ?Sized>(
         let mut memory = MEMORY_AMOUNT_LIMIT;
         let mut batch: Vec<Record> = Vec::new();
         let mut retry = false;
+        let mut seen_timestamps = if params.ext.is_some() {
+            Some(HashSet::new())
+        } else {
+            None
+        };
 
         while let Some(record) = record_stream.next().await {
             let record = match record {
@@ -646,6 +658,12 @@ async fn run_entry_copy<V: CopyVisitor + Sync + ?Sized>(
                     }
                 }
             };
+
+            if let Some(seen) = seen_timestamps.as_mut() {
+                if !seen.insert(record.timestamp_us()) {
+                    continue;
+                }
+            }
 
             let content_length = record.content_length() as isize;
             if content_length >= MEMORY_AMOUNT_LIMIT {


### PR DESCRIPTION
Closes #197

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix.

### What was changed?

- Removed the ROS-specific fail-fast validation that assumed plugin behavior.
- Updated copy query construction so `--ext-params` uses the batched v2 query path, which supports computed labels (e.g. `@...`) and avoids the v1 panic path.
- Added timestamp de-duplication in the forced multi-entry query flow.
- Added/updated regression tests around ROS extract ext params behavior.
- Updated `CHANGELOG.md` to describe the implemented fix.

### Related issues

- https://github.com/reductstore/reduct-cli/issues/197

### Does this PR introduce a breaking change?

No.