### PR TITLE
Add pre-built binary installation steps to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `attachment write`, `attachment ls`, `attachment read`, and `attachment rm` commands for entry attachments, [PR-184](https://github.com/reductstore/reduct-cli/pull/184)
 - Add global `--ca-cert` and persist alias connection options (`--ca-cert`, `--ignore-ssl`, `--timeout`, `--parallel`) in `alias add`, [PR-189](https://github.com/reductstore/reduct-cli/pull/189)
-- Add pre-built binary installation instructions to README for Linux, macOS, and Windows, [PR-199](https://github.com/reductstore/reduct-cli/pull/199)
+- Add pre-built binary installation instructions to README for Linux and Windows and link to additional release assets, [PR-199](https://github.com/reductstore/reduct-cli/pull/199)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `attachment write`, `attachment ls`, `attachment read`, and `attachment rm` commands for entry attachments, [PR-184](https://github.com/reductstore/reduct-cli/pull/184)
 - Add global `--ca-cert` and persist alias connection options (`--ca-cert`, `--ignore-ssl`, `--timeout`, `--parallel`) in `alias add`, [PR-189](https://github.com/reductstore/reduct-cli/pull/189)
+- Add pre-built binary installation instructions to README for Linux, macOS, and Windows, [PR-199](https://github.com/reductstore/reduct-cli/pull/199)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -19,11 +19,61 @@ blob data.
 
 ## Installing
 
+### From Cargo
+
 ```shell
 cargo install reduct-cli
 ```
 
-Or check pre-built binaries [here](https://github.com/reductstore/reduct-cli/releases/latest)
+### From pre-built binaries
+
+You can also install `reduct-cli` from the latest release binaries (same as on the Downloads page):
+
+#### Linux (amd64)
+
+```bash
+wget https://github.com/reductstore/reduct-cli/releases/latest/download/reduct-cli.x86_64-unknown-linux-gnu.tar.gz
+tar -xvf reduct-cli.x86_64-unknown-linux-gnu.tar.gz
+chmod +x reduct-cli
+sudo mv reduct-cli /usr/local/bin
+```
+
+#### Linux (arm64)
+
+```bash
+wget https://github.com/reductstore/reduct-cli/releases/latest/download/reduct-cli.aarch64-unknown-linux-gnu.tar.gz
+tar -xvf reduct-cli.aarch64-unknown-linux-gnu.tar.gz
+chmod +x reduct-cli
+sudo mv reduct-cli /usr/local/bin
+```
+
+#### macOS (Intel)
+
+```bash
+wget https://github.com/reductstore/reduct-cli/releases/latest/download/reduct-cli.x86_64-apple-darwin.tar.gz
+tar -xvf reduct-cli.x86_64-apple-darwin.tar.gz
+chmod +x reduct-cli
+sudo mv reduct-cli /usr/local/bin
+```
+
+#### macOS (Apple Silicon)
+
+```bash
+wget https://github.com/reductstore/reduct-cli/releases/latest/download/reduct-cli.aarch64-apple-darwin.tar.gz
+tar -xvf reduct-cli.aarch64-apple-darwin.tar.gz
+chmod +x reduct-cli
+sudo mv reduct-cli /usr/local/bin
+```
+
+#### Windows (amd64)
+
+```powershell
+Invoke-WebRequest -Uri https://github.com/reductstore/reduct-cli/releases/latest/download/reduct-cli.x86_64-pc-windows-gnu.zip -OutFile reduct-cli.zip
+Expand-Archive -LiteralPath reduct-cli.zip -DestinationPath .
+.\reduct-cli.exe
+```
+
+All available binaries and sources: [GitHub Releases](https://github.com/reductstore/reduct-cli/releases/latest)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -27,40 +27,13 @@ cargo install reduct-cli
 
 ### From pre-built binaries
 
-You can also install `reduct-cli` from the latest release binaries (same as on the Downloads page):
+You can also install `reduct-cli` from the latest release binaries.
 
 #### Linux (amd64)
 
 ```bash
 wget https://github.com/reductstore/reduct-cli/releases/latest/download/reduct-cli.x86_64-unknown-linux-gnu.tar.gz
 tar -xvf reduct-cli.x86_64-unknown-linux-gnu.tar.gz
-chmod +x reduct-cli
-sudo mv reduct-cli /usr/local/bin
-```
-
-#### Linux (arm64)
-
-```bash
-wget https://github.com/reductstore/reduct-cli/releases/latest/download/reduct-cli.aarch64-unknown-linux-gnu.tar.gz
-tar -xvf reduct-cli.aarch64-unknown-linux-gnu.tar.gz
-chmod +x reduct-cli
-sudo mv reduct-cli /usr/local/bin
-```
-
-#### macOS (Intel)
-
-```bash
-wget https://github.com/reductstore/reduct-cli/releases/latest/download/reduct-cli.x86_64-apple-darwin.tar.gz
-tar -xvf reduct-cli.x86_64-apple-darwin.tar.gz
-chmod +x reduct-cli
-sudo mv reduct-cli /usr/local/bin
-```
-
-#### macOS (Apple Silicon)
-
-```bash
-wget https://github.com/reductstore/reduct-cli/releases/latest/download/reduct-cli.aarch64-apple-darwin.tar.gz
-tar -xvf reduct-cli.aarch64-apple-darwin.tar.gz
 chmod +x reduct-cli
 sudo mv reduct-cli /usr/local/bin
 ```
@@ -73,7 +46,7 @@ Expand-Archive -LiteralPath reduct-cli.zip -DestinationPath .
 .\reduct-cli.exe
 ```
 
-All available binaries and sources: [GitHub Releases](https://github.com/reductstore/reduct-cli/releases/latest)
+We support many additional platforms. Download binaries and sources from the latest release: [GitHub Releases](https://github.com/reductstore/reduct-cli/releases/latest)
 
 ## Usage
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Docs update

### What was changed?

Updated `README.md` installation instructions for `reduct-cli`:
- kept Cargo install as the primary option;
- added a dedicated **From pre-built binaries** section;
- added platform-specific install commands for:
  - Linux (amd64, arm64)
  - macOS (Intel, Apple Silicon)
  - Windows (amd64)
- aligned binary links with the Downloads page assets and linked to the latest GitHub Releases page.

### Related issues

N/A

### Does this PR introduce a breaking change?

No.

### Other information:

Documentation-only change.
