### PR TITLE
Support nested entry paths and wildcards in entry path arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Support nested entry paths and wildcards in `cp`/`rm` bucket path arguments (e.g. `local/src/x/y`), [PR-200](https://github.com/reductstore/reduct-cli/pull/200)
 - Copy entry attachments during bucket-to-bucket `cp` transfers so metadata is preserved, [PR-196](https://github.com/reductstore/reduct-cli/pull/196)
 - Fix `cp` progress estimation to use time windows with `--start/--stop` and use record-count mode when a limit is set via `--limit` or `--when` (`$limit`), [PR-184](https://github.com/reductstore/reduct-cli/pull/184)
 

--- a/src/cmd/bucket/create.rs
+++ b/src/cmd/bucket/create.rs
@@ -9,6 +9,7 @@ use crate::context::CliContext;
 use crate::io::reduct::build_client;
 
 use crate::io::std::output;
+use crate::parse::Resource;
 use clap::{ArgMatches, Command};
 use reduct_rs::ReductClient;
 
@@ -18,12 +19,16 @@ pub(super) fn create_bucket_cmd() -> Command {
 }
 
 pub(super) async fn create_bucket(ctx: &CliContext, args: &ArgMatches) -> anyhow::Result<()> {
-    let (alias_or_url, bucket_name) = args.get_one::<(String, String)>("BUCKET_PATH").unwrap();
+    let (alias_or_url, bucket_name) = args
+        .get_one::<Resource>("BUCKET_PATH")
+        .unwrap()
+        .clone()
+        .pair()?;
     let bucket_settings = parse_bucket_settings(args);
 
-    let client: ReductClient = build_client(ctx, alias_or_url).await?;
+    let client: ReductClient = build_client(ctx, &alias_or_url).await?;
     client
-        .create_bucket(bucket_name)
+        .create_bucket(&bucket_name)
         .settings(bucket_settings)
         .send()
         .await?;

--- a/src/cmd/bucket/rename.rs
+++ b/src/cmd/bucket/rename.rs
@@ -2,6 +2,7 @@ use crate::context::CliContext;
 
 use crate::io::reduct::build_client;
 use crate::io::std::output;
+use crate::parse::Resource;
 use clap::{Arg, ArgMatches, Command};
 use reduct_rs::ReductClient;
 
@@ -29,18 +30,22 @@ pub(super) fn rename_bucket_cmd() -> Command {
 }
 
 pub(super) async fn rename_bucket(ctx: &CliContext, args: &ArgMatches) -> anyhow::Result<()> {
-    let (alias_or_url, bucket_name) = args.get_one::<(String, String)>("BUCKET_PATH").unwrap();
+    let (alias_or_url, bucket_name) = args
+        .get_one::<Resource>("BUCKET_PATH")
+        .unwrap()
+        .clone()
+        .pair()?;
     let new_name = args.get_one::<String>("NEW_NAME").unwrap();
     let entry_name = args.get_one::<String>("only-entry");
 
-    let client: ReductClient = build_client(ctx, alias_or_url).await?;
+    let client: ReductClient = build_client(ctx, &alias_or_url).await?;
     if let Some(entry_name) = entry_name {
-        let bucket = client.get_bucket(bucket_name).await?;
+        let bucket = client.get_bucket(&bucket_name).await?;
         bucket.rename_entry(entry_name, new_name).await?;
         output!(ctx, "Entry '{}' renamed to '{}'", entry_name, new_name);
     } else {
         client
-            .get_bucket(bucket_name)
+            .get_bucket(&bucket_name)
             .await?
             .rename(new_name)
             .await?;

--- a/src/cmd/bucket/rm.rs
+++ b/src/cmd/bucket/rm.rs
@@ -7,7 +7,7 @@ use crate::context::CliContext;
 use crate::cmd::RESOURCE_PATH_HELP;
 use crate::io::reduct::build_client;
 use crate::io::std::output;
-use crate::parse::{fetch_and_filter_entries, ResourcePathParser};
+use crate::parse::{fetch_and_filter_entries, Resource, ResourcePathParser};
 use clap::ArgAction::SetTrue;
 use clap::{Arg, ArgMatches, Command};
 use reduct_rs::ReductClient;
@@ -41,7 +41,11 @@ pub(super) fn rm_bucket_cmd() -> Command {
 }
 
 pub(super) async fn rm_bucket(ctx: &CliContext, args: &ArgMatches) -> anyhow::Result<()> {
-    let (alias_or_url, bucket_name) = args.get_one::<(String, String)>("BUCKET_PATH").unwrap();
+    let (alias_or_url, bucket_name) = args
+        .get_one::<Resource>("BUCKET_PATH")
+        .unwrap()
+        .clone()
+        .pair()?;
     let only_entries = args
         .get_many::<String>("only-entries")
         .unwrap_or_default()
@@ -49,9 +53,9 @@ pub(super) async fn rm_bucket(ctx: &CliContext, args: &ArgMatches) -> anyhow::Re
         .collect::<Vec<String>>();
 
     if !only_entries.is_empty() {
-        remove_entries(ctx, args, alias_or_url, bucket_name, only_entries).await?;
+        remove_entries(ctx, args, &alias_or_url, &bucket_name, only_entries).await?;
     } else {
-        remove_entire_bucket(ctx, args, alias_or_url, bucket_name).await?;
+        remove_entire_bucket(ctx, args, &alias_or_url, &bucket_name).await?;
     }
     Ok(())
 }
@@ -77,8 +81,8 @@ async fn remove_entire_bucket(
     };
 
     if confirm {
-        let client: ReductClient = build_client(ctx, alias_or_url).await?;
-        client.get_bucket(bucket_name).await?.remove().await?;
+        let client: ReductClient = build_client(ctx, &alias_or_url).await?;
+        client.get_bucket(&bucket_name).await?.remove().await?;
 
         output!(ctx, "Bucket '{}' deleted", bucket_name);
     } else {
@@ -94,8 +98,8 @@ async fn remove_entries(
     bucket_name: &String,
     only_entries: Vec<String>,
 ) -> anyhow::Result<()> {
-    let client: ReductClient = build_client(ctx, alias_or_url).await?;
-    let bucket = client.get_bucket(bucket_name).await?;
+    let client: ReductClient = build_client(ctx, &alias_or_url).await?;
+    let bucket = client.get_bucket(&bucket_name).await?;
 
     let entries = fetch_and_filter_entries(&bucket, &only_entries)
         .await?
@@ -207,7 +211,7 @@ mod tests {
     async fn wait_for_empty_entries(client: &ReductClient, bucket_name: &str) {
         for _ in 0..50 {
             let count = client
-                .get_bucket(bucket_name)
+                .get_bucket(&bucket_name)
                 .await
                 .unwrap()
                 .entries()
@@ -223,7 +227,7 @@ mod tests {
 
     async fn wait_for_bucket_removed(client: &ReductClient, bucket_name: &str) {
         for _ in 0..50 {
-            match client.get_bucket(bucket_name).await {
+            match client.get_bucket(&bucket_name).await {
                 Ok(_) => sleep(std::time::Duration::from_millis(100)).await,
                 Err(err) => {
                     if err.status() == ErrorCode::NotFound {
@@ -234,7 +238,12 @@ mod tests {
             }
         }
         assert_eq!(
-            client.get_bucket(bucket_name).await.err().unwrap().status(),
+            client
+                .get_bucket(&bucket_name)
+                .await
+                .err()
+                .unwrap()
+                .status(),
             ErrorCode::NotFound
         );
     }

--- a/src/cmd/bucket/show.rs
+++ b/src/cmd/bucket/show.rs
@@ -10,7 +10,7 @@ use crate::context::CliContext;
 use crate::helpers::timestamp_to_iso;
 use crate::io::reduct::build_client;
 use crate::io::std::output;
-use crate::parse::ResourcePathParser;
+use crate::parse::{Resource, ResourcePathParser};
 use bytesize::ByteSize;
 use clap::ArgAction::SetTrue;
 use clap::{Arg, ArgMatches, Command};
@@ -75,10 +75,14 @@ impl From<EntryInfo> for EntryTable {
 }
 
 pub(super) async fn show_bucket(ctx: &CliContext, args: &ArgMatches) -> anyhow::Result<()> {
-    let (alias_or_url, bucket_name) = args.get_one::<(String, String)>("BUCKET_PATH").unwrap();
+    let (alias_or_url, bucket_name) = args
+        .get_one::<Resource>("BUCKET_PATH")
+        .unwrap()
+        .clone()
+        .pair()?;
 
-    let client: ReductClient = build_client(ctx, alias_or_url).await?;
-    let bucket = client.get_bucket(bucket_name).await?.full_info().await?;
+    let client: ReductClient = build_client(ctx, &alias_or_url).await?;
+    let bucket = client.get_bucket(&bucket_name).await?.full_info().await?;
 
     if args.get_flag("full") {
         print_full_bucket(ctx, bucket)?;

--- a/src/cmd/bucket/update.rs
+++ b/src/cmd/bucket/update.rs
@@ -8,6 +8,7 @@ use crate::context::CliContext;
 
 use crate::io::reduct::build_client;
 use crate::io::std::output;
+use crate::parse::Resource;
 use clap::{ArgMatches, Command};
 use reduct_rs::ReductClient;
 
@@ -17,12 +18,16 @@ pub(super) fn update_bucket_cmd() -> Command {
 }
 
 pub(super) async fn update_bucket(ctx: &CliContext, args: &ArgMatches) -> anyhow::Result<()> {
-    let (alias_or_url, bucket_name) = args.get_one::<(String, String)>("BUCKET_PATH").unwrap();
+    let (alias_or_url, bucket_name) = args
+        .get_one::<Resource>("BUCKET_PATH")
+        .unwrap()
+        .clone()
+        .pair()?;
     let bucket_settings = parse_bucket_settings(args);
 
-    let client: ReductClient = build_client(ctx, alias_or_url).await?;
+    let client: ReductClient = build_client(ctx, &alias_or_url).await?;
     client
-        .get_bucket(bucket_name)
+        .get_bucket(&bucket_name)
         .await?
         .set_settings(bucket_settings)
         .await?;

--- a/src/cmd/cp.rs
+++ b/src/cmd/cp.rs
@@ -30,7 +30,11 @@ const CP_DEST_HELP: &str =
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum CpPath {
     Folder(String),
-    Bucket { instance: String, bucket: String },
+    Bucket {
+        instance: String,
+        bucket: String,
+        entry_path: Option<String>,
+    },
     Instance(String),
 }
 
@@ -82,19 +86,35 @@ impl TypedValueParser for CpPathParser {
                 return Ok(CpPath::Bucket {
                     instance: base_url.to_string(),
                     bucket: bucket.to_string(),
+                    entry_path: None,
                 });
             }
         }
 
-        if let Some((alias_or_url, resource_name)) = value.rsplit_once('/') {
-            if resource_name.is_empty() {
-                return Ok(CpPath::Instance(alias_or_url.to_string()));
+        if value.contains('/') {
+            let mut segments = value.split('/').filter(|segment| !segment.is_empty());
+            if let Some(instance) = segments.next() {
+                let bucket = segments.next();
+                let entry_segments: Vec<&str> = segments.collect();
+
+                if let Some(bucket) = bucket {
+                    let entry_path = if entry_segments.is_empty() {
+                        None
+                    } else {
+                        Some(entry_segments.join("/"))
+                    };
+                    return Ok(CpPath::Bucket {
+                        instance: instance.to_string(),
+                        bucket: bucket.to_string(),
+                        entry_path,
+                    });
+                }
+
+                return Ok(CpPath::Instance(instance.to_string()));
             }
-            Ok(CpPath::Bucket {
-                instance: alias_or_url.to_string(),
-                bucket: resource_name.to_string(),
-            })
-        } else if value.is_empty() {
+        }
+
+        if value.is_empty() {
             let mut err = Error::new(ErrorKind::ValueValidation).with_cmd(cmd);
             err.insert(
                 ContextKind::InvalidArg,
@@ -218,6 +238,7 @@ pub(crate) async fn cp_handler(ctx: &CliContext, args: &clap::ArgMatches) -> any
             CpPath::Bucket {
                 instance: src_instance,
                 bucket: src_bucket,
+                ..
             },
             CpPath::Instance(dst_instance),
         ) => {
@@ -304,6 +325,7 @@ async fn cp_all_buckets(
             &bucket.name,
             dst_instance,
             &bucket.name,
+            None,
         )
         .await?;
     }
@@ -345,6 +367,7 @@ async fn cp_matching_buckets(
             &bucket.name,
             dst_instance,
             &bucket.name,
+            None,
         )
         .await?;
     }
@@ -447,8 +470,12 @@ mod tests {
         let src = args.get_one::<CpPath>("SOURCE_BUCKET_OR_FOLDER").unwrap();
         assert!(matches!(
             src,
-            CpPath::Bucket { instance, bucket }
-            if instance == "https://reductstore@play.reduct.store/replica/" && bucket == "datasets"
+            CpPath::Bucket {
+                instance,
+                bucket,
+                entry_path,
+            }
+            if instance == "https://reductstore@play.reduct.store/replica/" && bucket == "datasets" && entry_path.is_none()
         ));
     }
 
@@ -464,6 +491,22 @@ mod tests {
             dst,
             CpPath::Instance(value)
             if value == "https://example.com/api/"
+        ));
+    }
+
+    #[test]
+    fn alias_bucket_with_nested_entry_path_parses_bucket_and_entry() {
+        let args = cp_cmd()
+            .try_get_matches_from(vec!["cp", "local/src/x/y", "./tmp"])
+            .unwrap();
+        let src = args.get_one::<CpPath>("SOURCE_BUCKET_OR_FOLDER").unwrap();
+        assert!(matches!(
+            src,
+            CpPath::Bucket {
+                instance,
+                bucket,
+                entry_path,
+            } if instance == "local" && bucket == "src" && entry_path.as_deref() == Some("x/y")
         ));
     }
 

--- a/src/cmd/cp.rs
+++ b/src/cmd/cp.rs
@@ -31,13 +31,13 @@ pub(crate) fn cp_cmd() -> Command {
         .arg(
             Arg::new("SOURCE_BUCKET_OR_FOLDER")
                 .help(CP_SOURCE_HELP)
-                .value_parser(ResourcePathParser::new())
+                .value_parser(ResourcePathParser::new().allow_alias().allow_folder())
                 .required(true),
         )
         .arg(
             Arg::new("DESTINATION_BUCKET_OR_FOLDER")
                 .help(CP_DEST_HELP)
-                .value_parser(ResourcePathParser::new())
+                .value_parser(ResourcePathParser::new().allow_alias().allow_folder())
                 .required(true),
         )
         .arg(

--- a/src/cmd/cp.rs
+++ b/src/cmd/cp.rs
@@ -15,118 +15,14 @@ use crate::io::std::output;
 use crate::parse::widely_used_args::{
     make_each_n, make_each_s, make_entries_arg, make_ext_arg, make_strict_arg, make_when_arg,
 };
-use clap::builder::TypedValueParser;
-use clap::error::{ContextKind, ContextValue, ErrorKind};
+use crate::parse::{Resource, ResourcePathParser};
 use clap::ArgAction::SetTrue;
-use clap::{value_parser, Arg, Command, Error};
-use std::ffi::OsStr;
-use url::Url;
+use clap::{value_parser, Arg, Command};
 
 const CP_SOURCE_HELP: &str =
     "Source bucket or folder (e.g. SERVER_ALIAS/BUCKET, SERVER_ALIAS/*, SERVER_ALIAS/test-*, or ./folder)";
 const CP_DEST_HELP: &str =
     "Destination bucket, instance, or folder (e.g. SERVER_ALIAS/BUCKET, SERVER_ALIAS, or ./folder)";
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum CpPath {
-    Folder(String),
-    Bucket {
-        instance: String,
-        bucket: String,
-        entry_path: Option<String>,
-    },
-    Instance(String),
-}
-
-#[derive(Clone)]
-struct CpPathParser;
-
-impl TypedValueParser for CpPathParser {
-    type Value = CpPath;
-
-    fn parse_ref(
-        &self,
-        cmd: &Command,
-        arg: Option<&Arg>,
-        value: &OsStr,
-    ) -> Result<Self::Value, Error> {
-        let value = value.to_string_lossy().to_string();
-        let is_folder = [".", "/", ".."].iter().any(|s| value.starts_with(s));
-        if is_folder {
-            return Ok(CpPath::Folder(value));
-        }
-
-        if let Ok(mut url) = Url::parse(&value) {
-            let scheme = url.scheme();
-            if scheme == "http" || scheme == "https" {
-                url.set_query(None);
-                url.set_fragment(None);
-
-                let path = url.path();
-                let has_trailing_slash = path.ends_with('/') && path != "/";
-                let mut segments: Vec<&str> = url
-                    .path_segments()
-                    .map(|segments| segments.filter(|segment| !segment.is_empty()).collect())
-                    .unwrap_or_default();
-
-                if segments.is_empty() || has_trailing_slash {
-                    return Ok(CpPath::Instance(url.to_string()));
-                }
-
-                let bucket = segments
-                    .pop()
-                    .ok_or_else(|| Error::new(ErrorKind::ValueValidation).with_cmd(cmd))?;
-                let base_path = if segments.is_empty() {
-                    "/".to_string()
-                } else {
-                    format!("/{}/", segments.join("/"))
-                };
-                let mut base_url = url.clone();
-                base_url.set_path(&base_path);
-                return Ok(CpPath::Bucket {
-                    instance: base_url.to_string(),
-                    bucket: bucket.to_string(),
-                    entry_path: None,
-                });
-            }
-        }
-
-        if value.contains('/') {
-            let mut segments = value.split('/').filter(|segment| !segment.is_empty());
-            if let Some(instance) = segments.next() {
-                let bucket = segments.next();
-                let entry_segments: Vec<&str> = segments.collect();
-
-                if let Some(bucket) = bucket {
-                    let entry_path = if entry_segments.is_empty() {
-                        None
-                    } else {
-                        Some(entry_segments.join("/"))
-                    };
-                    return Ok(CpPath::Bucket {
-                        instance: instance.to_string(),
-                        bucket: bucket.to_string(),
-                        entry_path,
-                    });
-                }
-
-                return Ok(CpPath::Instance(instance.to_string()));
-            }
-        }
-
-        if value.is_empty() {
-            let mut err = Error::new(ErrorKind::ValueValidation).with_cmd(cmd);
-            err.insert(
-                ContextKind::InvalidArg,
-                ContextValue::String(arg.unwrap().to_string()),
-            );
-            err.insert(ContextKind::InvalidValue, ContextValue::String(value));
-            Err(err)
-        } else {
-            Ok(CpPath::Instance(value))
-        }
-    }
-}
 
 pub(crate) fn cp_cmd() -> Command {
     Command::new("cp")
@@ -135,13 +31,13 @@ pub(crate) fn cp_cmd() -> Command {
         .arg(
             Arg::new("SOURCE_BUCKET_OR_FOLDER")
                 .help(CP_SOURCE_HELP)
-                .value_parser(CpPathParser)
+                .value_parser(ResourcePathParser::new())
                 .required(true),
         )
         .arg(
             Arg::new("DESTINATION_BUCKET_OR_FOLDER")
                 .help(CP_DEST_HELP)
-                .value_parser(CpPathParser)
+                .value_parser(ResourcePathParser::new())
                 .required(true),
         )
         .arg(
@@ -210,22 +106,26 @@ pub(crate) fn cp_cmd() -> Command {
 
 pub(crate) async fn cp_handler(ctx: &CliContext, args: &clap::ArgMatches) -> anyhow::Result<()> {
     let src = args
-        .get_one::<CpPath>("SOURCE_BUCKET_OR_FOLDER")
+        .get_one::<Resource>("SOURCE_BUCKET_OR_FOLDER")
         .unwrap()
         .clone();
     let dst = args
-        .get_one::<CpPath>("DESTINATION_BUCKET_OR_FOLDER")
+        .get_one::<Resource>("DESTINATION_BUCKET_OR_FOLDER")
         .unwrap()
         .clone();
 
     match (src, dst) {
-        (CpPath::Folder(_), CpPath::Folder(_)) => {
+        (Resource::Folder(_), Resource::Folder(_)) => {
             Err(anyhow::anyhow!("Folder to folder copy is not supported."))
         }
-        (CpPath::Folder(_), CpPath::Bucket { .. } | CpPath::Instance(_)) => {
-            Err(anyhow::anyhow!("Folder to bucket copy is not supported."))
-        }
-        (CpPath::Bucket { bucket, .. }, CpPath::Folder(_)) => {
+        (
+            Resource::Folder(_),
+            Resource::Resource(_, _) | Resource::ResourceWithPath(_, _, _) | Resource::Alias(_),
+        ) => Err(anyhow::anyhow!("Folder to bucket copy is not supported.")),
+        (
+            Resource::Resource(_, bucket) | Resource::ResourceWithPath(_, bucket, _),
+            Resource::Folder(_),
+        ) => {
             if bucket_wildcard_prefix(&bucket)?.is_some() {
                 return Err(anyhow::anyhow!(
                     "Wildcard bucket copy requires the destination to be an instance only."
@@ -235,12 +135,9 @@ pub(crate) async fn cp_handler(ctx: &CliContext, args: &clap::ArgMatches) -> any
             Ok(())
         }
         (
-            CpPath::Bucket {
-                instance: src_instance,
-                bucket: src_bucket,
-                ..
-            },
-            CpPath::Instance(dst_instance),
+            Resource::Resource(src_instance, src_bucket)
+            | Resource::ResourceWithPath(src_instance, src_bucket, _),
+            Resource::Alias(dst_instance),
         ) => {
             if let Some(prefix) = bucket_wildcard_prefix(&src_bucket)? {
                 if prefix.is_empty() {
@@ -260,12 +157,8 @@ pub(crate) async fn cp_handler(ctx: &CliContext, args: &clap::ArgMatches) -> any
             Ok(())
         }
         (
-            CpPath::Bucket {
-                bucket: src_bucket, ..
-            },
-            CpPath::Bucket {
-                bucket: dst_bucket, ..
-            },
+            Resource::Resource(_, src_bucket) | Resource::ResourceWithPath(_, src_bucket, _),
+            Resource::Resource(_, dst_bucket) | Resource::ResourceWithPath(_, dst_bucket, _),
         ) => {
             if bucket_wildcard_prefix(&src_bucket)?.is_some()
                 || bucket_wildcard_prefix(&dst_bucket)?.is_some()
@@ -277,7 +170,7 @@ pub(crate) async fn cp_handler(ctx: &CliContext, args: &clap::ArgMatches) -> any
             cp_bucket_to_bucket(ctx, args).await?;
             Ok(())
         }
-        (CpPath::Instance(_), _) => Err(anyhow::anyhow!(
+        (Resource::Alias(_), _) => Err(anyhow::anyhow!(
             "Source must include a bucket name or use '*' for all buckets."
         )),
     }
@@ -446,11 +339,11 @@ mod tests {
             .try_get_matches_from(vec!["cp", "local/bucket", "https://example.com"])
             .unwrap();
         let dst = args
-            .get_one::<CpPath>("DESTINATION_BUCKET_OR_FOLDER")
+            .get_one::<Resource>("DESTINATION_BUCKET_OR_FOLDER")
             .unwrap();
         assert!(matches!(
             dst,
-            CpPath::Instance(value)
+            Resource::Alias(value)
             if value == "https://example.com/"
         ));
 
@@ -467,15 +360,11 @@ mod tests {
                 "./tmp",
             ])
             .unwrap();
-        let src = args.get_one::<CpPath>("SOURCE_BUCKET_OR_FOLDER").unwrap();
+        let src = args.get_one::<Resource>("SOURCE_BUCKET_OR_FOLDER").unwrap();
         assert!(matches!(
             src,
-            CpPath::Bucket {
-                instance,
-                bucket,
-                entry_path,
-            }
-            if instance == "https://reductstore@play.reduct.store/replica/" && bucket == "datasets" && entry_path.is_none()
+            Resource::Resource(instance, bucket)
+            if instance == "https://reductstore@play.reduct.store/replica/" && bucket == "datasets"
         ));
     }
 
@@ -485,11 +374,11 @@ mod tests {
             .try_get_matches_from(vec!["cp", "local/bucket", "https://example.com/api/"])
             .unwrap();
         let dst = args
-            .get_one::<CpPath>("DESTINATION_BUCKET_OR_FOLDER")
+            .get_one::<Resource>("DESTINATION_BUCKET_OR_FOLDER")
             .unwrap();
         assert!(matches!(
             dst,
-            CpPath::Instance(value)
+            Resource::Alias(value)
             if value == "https://example.com/api/"
         ));
     }
@@ -499,14 +388,11 @@ mod tests {
         let args = cp_cmd()
             .try_get_matches_from(vec!["cp", "local/src/x/y", "./tmp"])
             .unwrap();
-        let src = args.get_one::<CpPath>("SOURCE_BUCKET_OR_FOLDER").unwrap();
+        let src = args.get_one::<Resource>("SOURCE_BUCKET_OR_FOLDER").unwrap();
         assert!(matches!(
             src,
-            CpPath::Bucket {
-                instance,
-                bucket,
-                entry_path,
-            } if instance == "local" && bucket == "src" && entry_path.as_deref() == Some("x/y")
+            Resource::ResourceWithPath(instance, bucket, entry_path)
+            if instance == "local" && bucket == "src" && entry_path == "x/y"
         ));
     }
 

--- a/src/cmd/cp/b2b.rs
+++ b/src/cmd/cp/b2b.rs
@@ -161,9 +161,7 @@ fn parse_bucket_pair(args: &ArgMatches, key: &str) -> anyhow::Result<(String, St
     let value = args.get_one::<CpPath>(key).unwrap();
     match value {
         CpPath::Bucket {
-            instance,
-            bucket,
-            ..
+            instance, bucket, ..
         } => Ok((instance.clone(), bucket.clone())),
         CpPath::Folder(_) => Err(anyhow::anyhow!(
             "Expected a bucket path for '{}', but got a folder path",

--- a/src/cmd/cp/b2b.rs
+++ b/src/cmd/cp/b2b.rs
@@ -4,10 +4,9 @@
 //    file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use crate::cmd::cp::helpers::{start_loading_with_entry_start_overrides, CopyVisitor};
-use crate::cmd::cp::CpPath;
 use crate::context::CliContext;
 use crate::io::reduct::build_client;
-use crate::parse::parse_query_params;
+use crate::parse::{parse_query_params, Resource};
 use clap::ArgMatches;
 use reduct_rs::{Bucket, ErrorCode, Record, ReductError};
 use serde_json::Value;
@@ -81,8 +80,8 @@ pub(crate) async fn cp_bucket_to_bucket(ctx: &CliContext, args: &ArgMatches) -> 
     let (src_instance, src_bucket) = parse_bucket_pair(args, "SOURCE_BUCKET_OR_FOLDER")?;
     let (dst_instance, dst_bucket) = parse_bucket_pair(args, "DESTINATION_BUCKET_OR_FOLDER")?;
 
-    let source_entry_filter = match args.get_one::<CpPath>("SOURCE_BUCKET_OR_FOLDER").unwrap() {
-        CpPath::Bucket { entry_path, .. } => entry_path.clone(),
+    let source_entry_filter = match args.get_one::<Resource>("SOURCE_BUCKET_OR_FOLDER").unwrap() {
+        Resource::ResourceWithPath(_, _, entry_path) => Some(entry_path.clone()),
         _ => None,
     };
 
@@ -158,16 +157,16 @@ pub(crate) async fn cp_bucket_to_bucket_with(
 }
 
 fn parse_bucket_pair(args: &ArgMatches, key: &str) -> anyhow::Result<(String, String)> {
-    let value = args.get_one::<CpPath>(key).unwrap();
+    let value = args.get_one::<Resource>(key).unwrap();
     match value {
-        CpPath::Bucket {
-            instance, bucket, ..
-        } => Ok((instance.clone(), bucket.clone())),
-        CpPath::Folder(_) => Err(anyhow::anyhow!(
+        Resource::Resource(instance, bucket) | Resource::ResourceWithPath(instance, bucket, _) => {
+            Ok((instance.clone(), bucket.clone()))
+        }
+        Resource::Folder(_) => Err(anyhow::anyhow!(
             "Expected a bucket path for '{}', but got a folder path",
             key
         )),
-        CpPath::Instance(_) => Err(anyhow::anyhow!(
+        Resource::Alias(_) => Err(anyhow::anyhow!(
             "Expected a bucket path for '{}', but got an instance only",
             key
         )),

--- a/src/cmd/cp/b2b.rs
+++ b/src/cmd/cp/b2b.rs
@@ -81,6 +81,11 @@ pub(crate) async fn cp_bucket_to_bucket(ctx: &CliContext, args: &ArgMatches) -> 
     let (src_instance, src_bucket) = parse_bucket_pair(args, "SOURCE_BUCKET_OR_FOLDER")?;
     let (dst_instance, dst_bucket) = parse_bucket_pair(args, "DESTINATION_BUCKET_OR_FOLDER")?;
 
+    let source_entry_filter = match args.get_one::<CpPath>("SOURCE_BUCKET_OR_FOLDER").unwrap() {
+        CpPath::Bucket { entry_path, .. } => entry_path.clone(),
+        _ => None,
+    };
+
     cp_bucket_to_bucket_with(
         ctx,
         args,
@@ -88,6 +93,7 @@ pub(crate) async fn cp_bucket_to_bucket(ctx: &CliContext, args: &ArgMatches) -> 
         &src_bucket,
         &dst_instance,
         &dst_bucket,
+        source_entry_filter,
     )
     .await
 }
@@ -99,8 +105,12 @@ pub(crate) async fn cp_bucket_to_bucket_with(
     src_bucket_name: &str,
     dst_instance: &str,
     dst_bucket_name: &str,
+    source_entry_filter: Option<String>,
 ) -> anyhow::Result<()> {
-    let query_params = parse_query_params(ctx, &args, Some(src_instance))?;
+    let mut query_params = parse_query_params(ctx, &args, Some(src_instance))?;
+    if let Some(entry_path) = source_entry_filter {
+        query_params.entry_filter.push(entry_path);
+    }
     let from_last = args.get_flag("from-last");
     if from_last && args.get_one::<String>("start").is_some() {
         return Err(anyhow::anyhow!("--from-last can't be used with --start"));
@@ -150,7 +160,11 @@ pub(crate) async fn cp_bucket_to_bucket_with(
 fn parse_bucket_pair(args: &ArgMatches, key: &str) -> anyhow::Result<(String, String)> {
     let value = args.get_one::<CpPath>(key).unwrap();
     match value {
-        CpPath::Bucket { instance, bucket } => Ok((instance.clone(), bucket.clone())),
+        CpPath::Bucket {
+            instance,
+            bucket,
+            ..
+        } => Ok((instance.clone(), bucket.clone())),
         CpPath::Folder(_) => Err(anyhow::anyhow!(
             "Expected a bucket path for '{}', but got a folder path",
             key

--- a/src/cmd/cp/b2f.rs
+++ b/src/cmd/cp/b2f.rs
@@ -4,7 +4,6 @@
 //    file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use crate::cmd::cp::helpers::{start_loading, CopyVisitor};
-use crate::cmd::cp::CpPath;
 use crate::context::CliContext;
 use crate::io::reduct::build_client;
 use clap::ArgMatches;
@@ -17,7 +16,7 @@ use std::path::PathBuf;
 
 use tokio::io::AsyncWriteExt;
 
-use crate::parse::parse_query_params;
+use crate::parse::{parse_query_params, Resource};
 use tokio::{fs, pin};
 
 struct CopyToFolderVisitor {
@@ -159,34 +158,33 @@ pub(crate) async fn cp_bucket_to_folder(ctx: &CliContext, args: &ArgMatches) -> 
     }
 
     let (src_instance, src_bucket, source_entry_filter) =
-        match args.get_one::<CpPath>("SOURCE_BUCKET_OR_FOLDER").unwrap() {
-            CpPath::Bucket {
-                instance,
-                bucket,
-                entry_path,
-            } => (instance.clone(), bucket.clone(), entry_path.clone()),
-            CpPath::Folder(_) => {
+        match args.get_one::<Resource>("SOURCE_BUCKET_OR_FOLDER").unwrap() {
+            Resource::Resource(instance, bucket) => (instance.clone(), bucket.clone(), None),
+            Resource::ResourceWithPath(instance, bucket, entry_path) => {
+                (instance.clone(), bucket.clone(), Some(entry_path.clone()))
+            }
+            Resource::Folder(_) => {
                 return Err(anyhow::anyhow!(
                     "Expected a bucket source, but got a folder path"
                 ))
             }
-            CpPath::Instance(_) => {
+            Resource::Alias(_) => {
                 return Err(anyhow::anyhow!(
                     "Expected a bucket source, but got an instance only"
                 ))
             }
         };
     let dst_folder = match args
-        .get_one::<CpPath>("DESTINATION_BUCKET_OR_FOLDER")
+        .get_one::<Resource>("DESTINATION_BUCKET_OR_FOLDER")
         .unwrap()
     {
-        CpPath::Folder(path) => PathBuf::from(path),
-        CpPath::Bucket { .. } => {
+        Resource::Folder(path) => PathBuf::from(path),
+        Resource::Resource(_, _) | Resource::ResourceWithPath(_, _, _) => {
             return Err(anyhow::anyhow!(
                 "Expected a folder destination, but got a bucket path"
             ))
         }
-        CpPath::Instance(_) => {
+        Resource::Alias(_) => {
             return Err(anyhow::anyhow!(
                 "Expected a folder destination, but got an instance only"
             ))

--- a/src/cmd/cp/b2f.rs
+++ b/src/cmd/cp/b2f.rs
@@ -158,9 +158,13 @@ pub(crate) async fn cp_bucket_to_folder(ctx: &CliContext, args: &ArgMatches) -> 
         ));
     }
 
-    let (src_instance, src_bucket) =
+    let (src_instance, src_bucket, source_entry_filter) =
         match args.get_one::<CpPath>("SOURCE_BUCKET_OR_FOLDER").unwrap() {
-            CpPath::Bucket { instance, bucket } => (instance.clone(), bucket.clone()),
+            CpPath::Bucket {
+                instance,
+                bucket,
+                entry_path,
+            } => (instance.clone(), bucket.clone(), entry_path.clone()),
             CpPath::Folder(_) => {
                 return Err(anyhow::anyhow!(
                     "Expected a bucket source, but got a folder path"
@@ -189,7 +193,10 @@ pub(crate) async fn cp_bucket_to_folder(ctx: &CliContext, args: &ArgMatches) -> 
         }
     };
 
-    let query_params = parse_query_params(ctx, &args, Some(&src_instance))?;
+    let mut query_params = parse_query_params(ctx, &args, Some(&src_instance))?;
+    if let Some(entry_path) = source_entry_filter {
+        query_params.entry_filter.push(entry_path);
+    }
     let src_bucket = build_client(ctx, &src_instance)
         .await?
         .get_bucket(&src_bucket)

--- a/src/cmd/replica/create.rs
+++ b/src/cmd/replica/create.rs
@@ -6,7 +6,7 @@
 use crate::cmd::RESOURCE_PATH_HELP;
 use crate::io::reduct::{build_client, parse_url_and_token};
 use crate::parse::widely_used_args::{make_each_n, make_each_s, make_entries_arg, make_when_arg};
-use crate::parse::ResourcePathParser;
+use crate::parse::{Resource, ResourcePathParser};
 use clap::{Arg, Command};
 use reduct_rs::ReplicationSettings;
 
@@ -42,12 +42,16 @@ pub(super) async fn create_replica(
     args: &clap::ArgMatches,
 ) -> anyhow::Result<()> {
     let (alias_or_url, replication_name) = args
-        .get_one::<(String, String)>("REPLICATION_PATH")
-        .unwrap();
+        .get_one::<Resource>("REPLICATION_PATH")
+        .unwrap()
+        .clone()
+        .pair()?;
     let source_bucket_name = args.get_one::<String>("SOURCE_BUCKET_NAME").unwrap();
     let (dest_alias_or_url, dest_bucket_name) = args
-        .get_one::<(String, String)>("DEST_BUCKET_PATH")
-        .unwrap();
+        .get_one::<Resource>("DEST_BUCKET_PATH")
+        .unwrap()
+        .clone()
+        .pair()?;
     let entries_filter = args
         .get_many::<String>("entries")
         .unwrap_or_default()
@@ -74,7 +78,7 @@ pub(super) async fn create_replica(
         settings.when = Some(serde_json::from_str(&when)?);
     }
     client
-        .create_replication(replication_name)
+        .create_replication(&replication_name)
         .set_settings(settings)
         .send()
         .await?;

--- a/src/cmd/replica/mode.rs
+++ b/src/cmd/replica/mode.rs
@@ -7,7 +7,7 @@ use crate::cmd::RESOURCE_PATH_HELP;
 use crate::context::CliContext;
 use crate::io::reduct::build_client;
 use crate::io::std::output;
-use crate::parse::ResourcePathParser;
+use crate::parse::{Resource, ResourcePathParser};
 use clap::{Arg, ArgMatches, Command};
 use reduct_rs::ReplicationMode;
 
@@ -39,11 +39,13 @@ async fn set_replica_mode(
     action: &str,
 ) -> anyhow::Result<()> {
     let (alias_or_url, replication_name) = args
-        .get_one::<(String, String)>("REPLICATION_PATH")
-        .unwrap();
+        .get_one::<Resource>("REPLICATION_PATH")
+        .unwrap()
+        .clone()
+        .pair()?;
 
-    let client = build_client(ctx, alias_or_url).await?;
-    client.set_replication_mode(replication_name, mode).await?;
+    let client = build_client(ctx, &alias_or_url).await?;
+    client.set_replication_mode(&replication_name, mode).await?;
 
     output!(ctx, "Replication '{}' {}", replication_name, action);
     Ok(())

--- a/src/cmd/replica/rm.rs
+++ b/src/cmd/replica/rm.rs
@@ -7,6 +7,7 @@ use crate::cmd::RESOURCE_PATH_HELP;
 use crate::context::CliContext;
 use crate::io::reduct::build_client;
 use crate::io::std::output;
+use crate::parse::Resource;
 use clap::ArgAction::SetTrue;
 use clap::{Arg, ArgMatches, Command};
 
@@ -31,8 +32,10 @@ pub(super) fn rm_replica_cmd() -> Command {
 
 pub(super) async fn rm_replica_handler(ctx: &CliContext, args: &ArgMatches) -> anyhow::Result<()> {
     let (alias_or_url, replication_name) = args
-        .get_one::<(String, String)>("REPLICATION_PATH")
-        .unwrap();
+        .get_one::<Resource>("REPLICATION_PATH")
+        .unwrap()
+        .clone()
+        .pair()?;
 
     let confirm = if !args.get_flag("yes") {
         let confirm = dialoguer::Confirm::new()
@@ -48,8 +51,8 @@ pub(super) async fn rm_replica_handler(ctx: &CliContext, args: &ArgMatches) -> a
     };
 
     if confirm {
-        let client = build_client(ctx, alias_or_url).await?;
-        client.delete_replication(replication_name).await?;
+        let client = build_client(ctx, &alias_or_url).await?;
+        client.delete_replication(&replication_name).await?;
         output!(ctx, "Replication '{}' deleted", replication_name);
     } else {
         output!(ctx, "Replication '{}' not deleted", replication_name);

--- a/src/cmd/replica/show.rs
+++ b/src/cmd/replica/show.rs
@@ -8,6 +8,7 @@ use crate::cmd::table::{build_info_table, labeled_cell};
 use crate::cmd::RESOURCE_PATH_HELP;
 use crate::io::reduct::build_client;
 use crate::io::std::output;
+use crate::parse::Resource;
 use clap::{Arg, Command};
 use tabled::settings::Style;
 use tabled::{Table, Tabled};
@@ -47,11 +48,13 @@ pub(super) async fn show_replica_handler(
     args: &clap::ArgMatches,
 ) -> anyhow::Result<()> {
     let (alias_or_url, replication_name) = args
-        .get_one::<(String, String)>("REPLICATION_PATH")
-        .unwrap();
-    let client = build_client(ctx, alias_or_url).await?;
+        .get_one::<Resource>("REPLICATION_PATH")
+        .unwrap()
+        .clone()
+        .pair()?;
+    let client = build_client(ctx, &alias_or_url).await?;
 
-    let replica = client.get_replication(replication_name).await?;
+    let replica = client.get_replication(&replication_name).await?;
 
     let mut info_cells = vec![
         labeled_cell("Name", replica.info.name.clone()),

--- a/src/cmd/replica/update.rs
+++ b/src/cmd/replica/update.rs
@@ -7,7 +7,7 @@ use crate::cmd::RESOURCE_PATH_HELP;
 use crate::context::CliContext;
 use crate::io::reduct::{build_client, parse_url_and_token};
 use crate::parse::widely_used_args::{make_each_n, make_each_s, make_entries_arg, make_when_arg};
-use crate::parse::ResourcePathParser;
+use crate::parse::{Resource, ResourcePathParser};
 
 use clap::{Arg, ArgMatches, Command};
 use reduct_rs::ReplicationSettings;
@@ -46,8 +46,10 @@ pub(super) async fn update_replica_handler(
     args: &ArgMatches,
 ) -> anyhow::Result<()> {
     let (alias_or_url, replication_name) = args
-        .get_one::<(String, String)>("REPLICATION_PATH")
-        .unwrap();
+        .get_one::<Resource>("REPLICATION_PATH")
+        .unwrap()
+        .clone()
+        .pair()?;
 
     let client = build_client(ctx, &alias_or_url).await?;
     let current_settings = client.get_replication(&replication_name).await?.settings;
@@ -66,8 +68,10 @@ fn update_replication_settings(
 ) -> anyhow::Result<ReplicationSettings> {
     // we require the destination bucket path because it is the only way to obtain the access token
     let (dest_alias_or_url, dest_bucket_name) = args
-        .get_one::<(String, String)>("DEST_BUCKET_PATH")
-        .unwrap();
+        .get_one::<Resource>("DEST_BUCKET_PATH")
+        .unwrap()
+        .clone()
+        .pair()?;
 
     let source_bucket_name = args.get_one::<String>("source-bucket");
 

--- a/src/cmd/rm.rs
+++ b/src/cmd/rm.rs
@@ -14,7 +14,9 @@ use crate::io::reduct::build_client;
 use crate::parse::widely_used_args::{
     make_each_n, make_each_s, make_entries_arg, make_strict_arg, make_when_arg,
 };
-use crate::parse::{fetch_and_filter_entries, parse_query_params, QueryParams};
+use crate::parse::{
+    fetch_and_filter_entries, parse_query_params, QueryParams, Resource, ResourcePathParser,
+};
 use async_trait::async_trait;
 use clap::{Arg, Command};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
@@ -30,6 +32,7 @@ pub(crate) fn rm_cmd() -> Command {
         .arg(
             Arg::new("BUCKET_PATH")
                 .help(ALIAS_OR_URL_HELP)
+                .value_parser(ResourcePathParser::new())
                 .required(true),
         )
         .arg(
@@ -63,8 +66,8 @@ pub(crate) fn rm_cmd() -> Command {
 }
 
 pub(crate) async fn rm_handler(ctx: &CliContext, args: &clap::ArgMatches) -> anyhow::Result<()> {
-    let bucket_path = args.get_one::<String>("BUCKET_PATH").unwrap();
-    let (alias, bucket, entry_path) = parse_bucket_path(bucket_path)?;
+    let bucket_path = args.get_one::<Resource>("BUCKET_PATH").unwrap().clone();
+    let (alias, bucket, entry_path) = bucket_path.triple()?;
     let mut query_params = parse_query_params(ctx, &args, Some(alias.as_str()))?;
     if let Some(entry_path) = entry_path {
         query_params.entry_filter.push(entry_path);
@@ -122,58 +125,6 @@ pub(crate) async fn rm_handler(ctx: &CliContext, args: &clap::ArgMatches) -> any
         let _ = result?;
     }
     Ok(())
-}
-
-fn parse_bucket_path(path: &str) -> anyhow::Result<(String, String, Option<String>)> {
-    if let Ok(mut url) = url::Url::parse(path) {
-        let scheme = url.scheme();
-        if scheme == "http" || scheme == "https" {
-            url.set_query(None);
-            url.set_fragment(None);
-
-            let mut segments: Vec<String> = url
-                .path_segments()
-                .map(|segments| {
-                    segments
-                        .filter(|segment| !segment.is_empty())
-                        .map(|s| s.to_string())
-                        .collect()
-                })
-                .unwrap_or_default();
-
-            if segments.is_empty() {
-                return Err(anyhow::anyhow!(
-                    "Bucket path must include a bucket (e.g. http://host/BUCKET)"
-                ));
-            }
-
-            let bucket = segments.remove(0).to_string();
-            let entry_path = if segments.is_empty() {
-                None
-            } else {
-                Some(segments.join("/"))
-            };
-
-            url.set_path("/");
-            return Ok((url.to_string(), bucket, entry_path));
-        }
-    }
-
-    let mut segments = path.split('/').filter(|segment| !segment.is_empty());
-    let alias = segments
-        .next()
-        .ok_or_else(|| anyhow::anyhow!("Bucket path must be in the format ALIAS/BUCKET"))?;
-    let bucket = segments
-        .next()
-        .ok_or_else(|| anyhow::anyhow!("Bucket path must be in the format ALIAS/BUCKET"))?;
-    let rest: Vec<&str> = segments.collect();
-    let entry_path = if rest.is_empty() {
-        None
-    } else {
-        Some(rest.join("/"))
-    };
-
-    Ok((alias.to_string(), bucket.to_string(), entry_path))
 }
 
 /// Trait for removing records from a bucket
@@ -279,7 +230,10 @@ mod tests {
 
     #[test]
     fn test_parse_bucket_path_with_nested_entry() {
-        let (alias, bucket, entry) = parse_bucket_path("local/src/x/y").unwrap();
+        let (alias, bucket, entry) =
+            Resource::ResourceWithPath("local".to_string(), "src".to_string(), "x/y".to_string())
+                .triple()
+                .unwrap();
         assert_eq!(alias, "local");
         assert_eq!(bucket, "src");
         assert_eq!(entry.as_deref(), Some("x/y"));

--- a/src/cmd/rm.rs
+++ b/src/cmd/rm.rs
@@ -14,7 +14,7 @@ use crate::io::reduct::build_client;
 use crate::parse::widely_used_args::{
     make_each_n, make_each_s, make_entries_arg, make_strict_arg, make_when_arg,
 };
-use crate::parse::{fetch_and_filter_entries, parse_query_params, QueryParams, ResourcePathParser};
+use crate::parse::{fetch_and_filter_entries, parse_query_params, QueryParams};
 use async_trait::async_trait;
 use clap::{Arg, Command};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
@@ -30,7 +30,6 @@ pub(crate) fn rm_cmd() -> Command {
         .arg(
             Arg::new("BUCKET_PATH")
                 .help(ALIAS_OR_URL_HELP)
-                .value_parser(ResourcePathParser::new())
                 .required(true),
         )
         .arg(
@@ -64,8 +63,12 @@ pub(crate) fn rm_cmd() -> Command {
 }
 
 pub(crate) async fn rm_handler(ctx: &CliContext, args: &clap::ArgMatches) -> anyhow::Result<()> {
-    let (alias, bucket) = args.get_one::<(String, String)>("BUCKET_PATH").unwrap();
-    let query_params = parse_query_params(ctx, &args, Some(alias.as_str()))?;
+    let bucket_path = args.get_one::<String>("BUCKET_PATH").unwrap();
+    let (alias, bucket, entry_path) = parse_bucket_path(bucket_path)?;
+    let mut query_params = parse_query_params(ctx, &args, Some(alias.as_str()))?;
+    if let Some(entry_path) = entry_path {
+        query_params.entry_filter.push(entry_path);
+    }
     let timestamps = args
         .get_many::<String>("time")
         .map(|values| values.map(|s| s.clone()).collect::<Vec<String>>());
@@ -119,6 +122,58 @@ pub(crate) async fn rm_handler(ctx: &CliContext, args: &clap::ArgMatches) -> any
         let _ = result?;
     }
     Ok(())
+}
+
+fn parse_bucket_path(path: &str) -> anyhow::Result<(String, String, Option<String>)> {
+    if let Ok(mut url) = url::Url::parse(path) {
+        let scheme = url.scheme();
+        if scheme == "http" || scheme == "https" {
+            url.set_query(None);
+            url.set_fragment(None);
+
+            let mut segments: Vec<String> = url
+                .path_segments()
+                .map(|segments| {
+                    segments
+                        .filter(|segment| !segment.is_empty())
+                        .map(|s| s.to_string())
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            if segments.is_empty() {
+                return Err(anyhow::anyhow!(
+                    "Bucket path must include a bucket (e.g. http://host/BUCKET)"
+                ));
+            }
+
+            let bucket = segments.remove(0).to_string();
+            let entry_path = if segments.is_empty() {
+                None
+            } else {
+                Some(segments.join("/"))
+            };
+
+            url.set_path("/");
+            return Ok((url.to_string(), bucket, entry_path));
+        }
+    }
+
+    let mut segments = path.split('/').filter(|segment| !segment.is_empty());
+    let alias = segments
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("Bucket path must be in the format ALIAS/BUCKET"))?;
+    let bucket = segments
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("Bucket path must be in the format ALIAS/BUCKET"))?;
+    let rest: Vec<&str> = segments.collect();
+    let entry_path = if rest.is_empty() {
+        None
+    } else {
+        Some(rest.join("/"))
+    };
+
+    Ok((alias.to_string(), bucket.to_string(), entry_path))
 }
 
 /// Trait for removing records from a bucket
@@ -220,6 +275,14 @@ mod tests {
             .err()
             .unwrap();
         assert_eq!(err.status(), ErrorCode::NotFound);
+    }
+
+    #[test]
+    fn test_parse_bucket_path_with_nested_entry() {
+        let (alias, bucket, entry) = parse_bucket_path("local/src/x/y").unwrap();
+        assert_eq!(alias, "local");
+        assert_eq!(bucket, "src");
+        assert_eq!(entry.as_deref(), Some("x/y"));
     }
 
     #[fixture]

--- a/src/cmd/token/create.rs
+++ b/src/cmd/token/create.rs
@@ -7,7 +7,7 @@ use crate::cmd::RESOURCE_PATH_HELP;
 use crate::context::CliContext;
 use crate::io::reduct::build_client;
 use crate::io::std::output;
-use crate::parse::ResourcePathParser;
+use crate::parse::{Resource, ResourcePathParser};
 use clap::ArgAction::SetTrue;
 use clap::{Arg, ArgMatches, Command};
 use reduct_rs::{Permissions, ReductClient};
@@ -50,7 +50,11 @@ pub(super) fn create_token_cmd() -> Command {
 }
 
 pub(super) async fn create_token(ctx: &CliContext, args: &ArgMatches) -> anyhow::Result<()> {
-    let (alias_or_url, token_name) = args.get_one::<(String, String)>("TOKEN_PATH").unwrap();
+    let (alias_or_url, token_name) = args
+        .get_one::<Resource>("TOKEN_PATH")
+        .unwrap()
+        .clone()
+        .pair()?;
     let full_access = args.get_flag("full-access");
     let read_buckets = args
         .get_many::<String>("read-bucket")
@@ -63,10 +67,10 @@ pub(super) async fn create_token(ctx: &CliContext, args: &ArgMatches) -> anyhow:
         .map(|s| s.to_string())
         .collect::<Vec<String>>();
 
-    let client: ReductClient = build_client(ctx, alias_or_url).await?;
+    let client: ReductClient = build_client(ctx, &alias_or_url).await?;
     let token = client
         .create_token(
-            token_name,
+            &token_name,
             Permissions {
                 full_access,
                 read: read_buckets,

--- a/src/cmd/token/rm.rs
+++ b/src/cmd/token/rm.rs
@@ -7,7 +7,7 @@ use crate::cmd::RESOURCE_PATH_HELP;
 use crate::context::CliContext;
 use crate::io::reduct::build_client;
 use crate::io::std::output;
-use crate::parse::ResourcePathParser;
+use crate::parse::{Resource, ResourcePathParser};
 use clap::ArgAction::SetTrue;
 use clap::{Arg, ArgMatches, Command};
 
@@ -32,7 +32,11 @@ pub(super) fn rm_token_cmd() -> Command {
 }
 
 pub(super) async fn rm_token(ctx: &CliContext, args: &ArgMatches) -> anyhow::Result<()> {
-    let (alias_or_url, token_name) = args.get_one::<(String, String)>("TOKEN_PATH").unwrap();
+    let (alias_or_url, token_name) = args
+        .get_one::<Resource>("TOKEN_PATH")
+        .unwrap()
+        .clone()
+        .pair()?;
 
     let confirm = if !args.get_flag("yes") {
         let confirm = dialoguer::Confirm::new()
@@ -48,8 +52,8 @@ pub(super) async fn rm_token(ctx: &CliContext, args: &ArgMatches) -> anyhow::Res
     };
 
     if confirm {
-        let client = build_client(ctx, alias_or_url).await?;
-        client.delete_token(token_name).await?;
+        let client = build_client(ctx, &alias_or_url).await?;
+        client.delete_token(&token_name).await?;
         output!(ctx, "Token '{}' deleted", token_name);
     } else {
         output!(ctx, "Token '{}' not deleted", token_name);

--- a/src/cmd/token/show.rs
+++ b/src/cmd/token/show.rs
@@ -7,7 +7,7 @@ use crate::cmd::RESOURCE_PATH_HELP;
 use crate::context::CliContext;
 use crate::io::reduct::build_client;
 use crate::io::std::output;
-use crate::parse::ResourcePathParser;
+use crate::parse::{Resource, ResourcePathParser};
 
 use clap::{Arg, ArgMatches, Command};
 
@@ -24,10 +24,14 @@ pub(super) fn show_token_cmd() -> Command {
 }
 
 pub(super) async fn show_token(ctx: &CliContext, args: &ArgMatches) -> anyhow::Result<()> {
-    let (alias_or_url, token_name) = args.get_one::<(String, String)>("TOKEN_PATH").unwrap();
+    let (alias_or_url, token_name) = args
+        .get_one::<Resource>("TOKEN_PATH")
+        .unwrap()
+        .clone()
+        .pair()?;
 
-    let client = build_client(ctx, alias_or_url).await?;
-    let token = client.get_token(token_name).await?;
+    let client = build_client(ctx, &alias_or_url).await?;
+    let token = client.get_token(&token_name).await?;
 
     let bool_icon = |value: bool| if value { "✓" } else { "-" };
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -12,4 +12,4 @@ pub(crate) mod widely_used_args;
 pub(crate) use byte_size::ByteSizeParser;
 pub(crate) use helpers::{fetch_and_filter_entries, parse_query_params, parse_time, QueryParams};
 pub(crate) use quota_type::QuotaTypeParser;
-pub(crate) use resource_path::ResourcePathParser;
+pub(crate) use resource_path::{Resource, ResourcePathParser};

--- a/src/parse/resource_path.rs
+++ b/src/parse/resource_path.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-2024 ReductStore
+// Copyright 2023-2026 ReductStore
 // This Source Code Form is subject to the terms of the Mozilla Public
 //    License, v. 2.0. If a copy of the MPL was not distributed with this
 //    file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -7,12 +7,47 @@ use clap::builder::TypedValueParser;
 use clap::error::{ContextKind, ContextValue, ErrorKind};
 use clap::{Arg, Command, Error};
 use std::ffi::OsStr;
+use url::Url;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum Resource {
+    Folder(String),
+    Alias(String),
+    Resource(String, String),
+    ResourceWithPath(String, String, String),
+}
+
+impl Resource {
+    pub(crate) fn pair(self) -> anyhow::Result<(String, String)> {
+        match self {
+            Resource::Resource(alias_or_url, resource) => Ok((alias_or_url, resource)),
+            Resource::ResourceWithPath(alias_or_url, resource, _) => Ok((alias_or_url, resource)),
+            Resource::Folder(_) => Err(anyhow::anyhow!("Expected ALIAS/RESOURCE path, got folder")),
+            Resource::Alias(_) => Err(anyhow::anyhow!(
+                "Expected ALIAS/RESOURCE path, got alias/instance only"
+            )),
+        }
+    }
+
+    pub(crate) fn triple(self) -> anyhow::Result<(String, String, Option<String>)> {
+        match self {
+            Resource::Resource(alias_or_url, resource) => Ok((alias_or_url, resource, None)),
+            Resource::ResourceWithPath(alias_or_url, resource, path) => {
+                Ok((alias_or_url, resource, Some(path)))
+            }
+            Resource::Folder(_) => Err(anyhow::anyhow!("Expected ALIAS/RESOURCE path, got folder")),
+            Resource::Alias(_) => Err(anyhow::anyhow!(
+                "Expected ALIAS/RESOURCE path, got alias/instance only"
+            )),
+        }
+    }
+}
 
 #[derive(Clone)]
 pub(crate) struct ResourcePathParser {}
 
 impl TypedValueParser for ResourcePathParser {
-    type Value = (String, String);
+    type Value = Resource;
 
     fn parse_ref(
         &self,
@@ -23,20 +58,71 @@ impl TypedValueParser for ResourcePathParser {
         let value = value.to_string_lossy().to_string();
         let is_folder = [".", "/", ".."].iter().any(|s| value.starts_with(s));
         if is_folder {
-            return Ok((value, "".to_string()));
+            return Ok(Resource::Folder(value));
         }
 
-        if let Some((alias_or_url, resource_name)) = value.rsplit_once('/') {
-            Ok((alias_or_url.to_string(), resource_name.to_string()))
-        } else {
-            let mut err = Error::new(ErrorKind::ValueValidation).with_cmd(cmd);
-            err.insert(
-                ContextKind::InvalidArg,
-                ContextValue::String(arg.unwrap().to_string()),
-            );
-            err.insert(ContextKind::InvalidValue, ContextValue::String(value));
-            Err(err)
+        if let Ok(mut url) = Url::parse(&value) {
+            let scheme = url.scheme();
+            if scheme == "http" || scheme == "https" {
+                url.set_query(None);
+                url.set_fragment(None);
+
+                let path = url.path();
+                let has_trailing_slash = path.ends_with('/') && path != "/";
+                let segments: Vec<String> = url
+                    .path_segments()
+                    .map(|segments| {
+                        segments
+                            .filter(|segment| !segment.is_empty())
+                            .map(|s| s.to_string())
+                            .collect()
+                    })
+                    .unwrap_or_default();
+
+                if segments.is_empty() || has_trailing_slash {
+                    return Ok(Resource::Alias(url.to_string()));
+                }
+
+                let resource = segments
+                    .last()
+                    .cloned()
+                    .ok_or_else(|| Error::new(ErrorKind::ValueValidation).with_cmd(cmd))?;
+
+                let mut base_url = url.clone();
+                if segments.len() <= 1 {
+                    base_url.set_path("/");
+                } else {
+                    base_url.set_path(&format!("/{}/", segments[..segments.len() - 1].join("/")));
+                }
+
+                return Ok(Resource::Resource(base_url.to_string(), resource));
+            }
         }
+
+        let segments: Vec<&str> = value
+            .split('/')
+            .filter(|segment| !segment.is_empty())
+            .collect();
+        let parsed = match segments.len() {
+            0 => {
+                let mut err = Error::new(ErrorKind::ValueValidation).with_cmd(cmd);
+                err.insert(
+                    ContextKind::InvalidArg,
+                    ContextValue::String(arg.unwrap().to_string()),
+                );
+                err.insert(ContextKind::InvalidValue, ContextValue::String(value));
+                return Err(err);
+            }
+            1 => Resource::Alias(segments[0].to_string()),
+            2 => Resource::Resource(segments[0].to_string(), segments[1].to_string()),
+            _ => Resource::ResourceWithPath(
+                segments[0].to_string(),
+                segments[1].to_string(),
+                segments[2..].join("/"),
+            ),
+        };
+
+        Ok(parsed)
     }
 }
 

--- a/src/parse/resource_path.rs
+++ b/src/parse/resource_path.rs
@@ -44,7 +44,10 @@ impl Resource {
 }
 
 #[derive(Clone)]
-pub(crate) struct ResourcePathParser {}
+pub(crate) struct ResourcePathParser {
+    allow_alias: bool,
+    allow_folder: bool,
+}
 
 impl TypedValueParser for ResourcePathParser {
     type Value = Resource;
@@ -58,7 +61,16 @@ impl TypedValueParser for ResourcePathParser {
         let value = value.to_string_lossy().to_string();
         let is_folder = [".", "/", ".."].iter().any(|s| value.starts_with(s));
         if is_folder {
-            return Ok(Resource::Folder(value));
+            if self.allow_folder {
+                return Ok(Resource::Folder(value));
+            }
+            let mut err = Error::new(ErrorKind::ValueValidation).with_cmd(cmd);
+            err.insert(
+                ContextKind::InvalidArg,
+                ContextValue::String(arg.unwrap().to_string()),
+            );
+            err.insert(ContextKind::InvalidValue, ContextValue::String(value));
+            return Err(err);
         }
 
         if let Ok(mut url) = Url::parse(&value) {
@@ -80,7 +92,16 @@ impl TypedValueParser for ResourcePathParser {
                     .unwrap_or_default();
 
                 if segments.is_empty() || has_trailing_slash {
-                    return Ok(Resource::Alias(url.to_string()));
+                    if self.allow_alias {
+                        return Ok(Resource::Alias(url.to_string()));
+                    }
+                    let mut err = Error::new(ErrorKind::ValueValidation).with_cmd(cmd);
+                    err.insert(
+                        ContextKind::InvalidArg,
+                        ContextValue::String(arg.unwrap().to_string()),
+                    );
+                    err.insert(ContextKind::InvalidValue, ContextValue::String(value));
+                    return Err(err);
                 }
 
                 let resource = segments
@@ -113,7 +134,19 @@ impl TypedValueParser for ResourcePathParser {
                 err.insert(ContextKind::InvalidValue, ContextValue::String(value));
                 return Err(err);
             }
-            1 => Resource::Alias(segments[0].to_string()),
+            1 => {
+                if self.allow_alias {
+                    Resource::Alias(segments[0].to_string())
+                } else {
+                    let mut err = Error::new(ErrorKind::ValueValidation).with_cmd(cmd);
+                    err.insert(
+                        ContextKind::InvalidArg,
+                        ContextValue::String(arg.unwrap().to_string()),
+                    );
+                    err.insert(ContextKind::InvalidValue, ContextValue::String(value));
+                    return Err(err);
+                }
+            }
             2 => Resource::Resource(segments[0].to_string(), segments[1].to_string()),
             _ => Resource::ResourceWithPath(
                 segments[0].to_string(),
@@ -128,6 +161,19 @@ impl TypedValueParser for ResourcePathParser {
 
 impl ResourcePathParser {
     pub fn new() -> Self {
-        Self {}
+        Self {
+            allow_alias: false,
+            allow_folder: false,
+        }
+    }
+
+    pub fn allow_alias(mut self) -> Self {
+        self.allow_alias = true;
+        self
+    }
+
+    pub fn allow_folder(mut self) -> Self {
+        self.allow_folder = true;
+        self
     }
 }


### PR DESCRIPTION
Closes #193

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix / CLI UX improvement

### What was changed?

- Updated `cp` path parsing to support nested entry paths in source bucket arguments, e.g. `local/src/x/y` now resolves to:
  - instance/alias: `local`
  - bucket: `src`
  - entry path filter: `x/y`
- Threaded parsed source entry-path filters into `cp` copy query params for both:
  - bucket-to-bucket copy
  - bucket-to-folder copy
- Updated `rm` bucket-path parsing to support nested entry paths in positional `BUCKET_PATH`:
  - first segment is alias/instance
  - second segment is bucket
  - remaining segments become entry-path filter (supports nested paths and wildcards)
- Added parser-focused tests for nested entry path handling (`cp` and `rm`).

### Related issues

- https://github.com/reductstore/reduct-cli/issues/193

### Does this PR introduce a breaking change?

No.

### Other information:

- Full integration test suite requires a local ReductStore test server (`localhost:8383`); parser and compile checks were validated locally.