### PR TITLE
Update token commands for token API v2 (#166)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `attachment write`, `attachment ls`, `attachment read`, and `attachment rm` commands for entry attachments, [PR-184](https://github.com/reductstore/reduct-cli/pull/184)
 - Add global `--ca-cert` and persist alias connection options (`--ca-cert`, `--ignore-ssl`, `--timeout`, `--parallel`) in `alias add`, [PR-189](https://github.com/reductstore/reduct-cli/pull/189)
 - Add pre-built binary installation instructions to README for Linux and Windows and link to additional release assets, [PR-199](https://github.com/reductstore/reduct-cli/pull/199)
+- Update token commands for token API v2 (`token create --ttl/--expires-at/--expires-in/--ip-allow`, `token rotate`, and extended `token ls/show` metadata), [PR-202](https://github.com/reductstore/reduct-cli/pull/202)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,9 +135,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -145,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",
@@ -193,9 +193,9 @@ checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -264,9 +264,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -487,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
 
 [[package]]
 name = "find-msvc-tools"
@@ -520,9 +520,12 @@ dependencies = [
 
 [[package]]
 name = "fragile"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
+checksum = "8878864ba14bb86e818a412bfd6f18f9eabd4ec0f008a28e8f7eb61db532fcf9"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "fs_extra"
@@ -732,9 +735,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -745,7 +748,6 @@ dependencies = [
  "httparse",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -816,12 +818,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -829,9 +832,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -842,9 +845,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -856,15 +859,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -876,15 +879,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -924,9 +927,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -967,9 +970,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -983,9 +986,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
@@ -996,7 +999,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -1005,9 +1008,31 @@ dependencies = [
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jobserver"
@@ -1021,10 +1046,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1037,15 +1064,15 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
  "libc",
 ]
@@ -1058,9 +1085,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -1104,9 +1131,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -1141,9 +1168,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-traits"
@@ -1208,12 +1235,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1221,9 +1242,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -1515,7 +1536,7 @@ dependencies = [
 [[package]]
 name = "reduct-rs"
 version = "1.19.0"
-source = "git+https://github.com/reductstore/reduct-rs?branch=main#831e9072011866c421b071e66264a305099df675"
+source = "git+https://github.com/reductstore/reduct-rs?branch=main#360d6641abbee4d6e7c4847d071222f0efbdc1f1"
 dependencies = [
  "async-channel",
  "async-stream",
@@ -1653,9 +1674,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -1744,9 +1765,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -1803,9 +1824,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1853,9 +1874,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -2084,9 +2105,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2109,9 +2130,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
 dependencies = [
  "bytes",
  "libc",
@@ -2124,9 +2145,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2158,9 +2179,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399b1124a3c9e16766831c6bba21e50192572cdd98706ea114f9502509686ffc"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -2173,18 +2194,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.4+spec-1.1.0"
+version = "0.25.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
+checksum = "a82418ca169e235e6c399a84e395ab6debeb3bc90edc959bf0f48647c6a32d1b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -2194,18 +2215,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -2389,9 +2410,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2402,23 +2423,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2426,9 +2443,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2439,9 +2456,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -2495,9 +2512,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2814,9 +2831,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]
@@ -2911,15 +2928,15 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -2928,9 +2945,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2940,18 +2957,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2960,18 +2977,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2987,9 +3004,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -2998,9 +3015,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3009,9 +3026,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/cmd/token.rs
+++ b/src/cmd/token.rs
@@ -6,11 +6,13 @@
 mod create;
 mod ls;
 mod rm;
+mod rotate;
 mod show;
 
 use crate::cmd::token::create::create_token_cmd;
 use crate::cmd::token::ls::ls_tokens_cmd;
 use crate::cmd::token::rm::rm_token_cmd;
+use crate::cmd::token::rotate::rotate_token_cmd;
 use crate::cmd::token::show::{show_token, show_token_cmd};
 use crate::context::CliContext;
 use clap::Command;
@@ -21,6 +23,7 @@ pub(crate) fn token_cmd() -> Command {
         .arg_required_else_help(true)
         .subcommand(create_token_cmd())
         .subcommand(ls_tokens_cmd())
+        .subcommand(rotate_token_cmd())
         .subcommand(show_token_cmd())
         .subcommand(rm_token_cmd())
 }
@@ -33,6 +36,7 @@ pub(crate) async fn token_handler(
         Some(("create", args)) => create::create_token(ctx, args).await?,
         Some(("show", args)) => show_token(ctx, args).await?,
         Some(("ls", args)) => ls::ls_tokens(ctx, args).await?,
+        Some(("rotate", args)) => rotate::rotate_token(ctx, args).await?,
         Some(("rm", args)) => rm::rm_token(ctx, args).await?,
         _ => (),
     }

--- a/src/cmd/token/create.rs
+++ b/src/cmd/token/create.rs
@@ -8,9 +8,10 @@ use crate::context::CliContext;
 use crate::io::reduct::build_client;
 use crate::io::std::output;
 use crate::parse::{Resource, ResourcePathParser};
-use clap::ArgAction::SetTrue;
+use chrono::{DateTime, Utc};
+use clap::ArgAction::{Append, SetTrue};
 use clap::{Arg, ArgMatches, Command};
-use reduct_rs::{Permissions, ReductClient};
+use reduct_rs::{Permissions, ReductClient, TokenCreateOptions};
 
 pub(super) fn create_token_cmd() -> Command {
     Command::new("create")
@@ -47,6 +48,32 @@ pub(super) fn create_token_cmd() -> Command {
                 .help("Bucket to give write access to. Can be used multiple times")
                 .required(false),
         )
+        .arg(
+            Arg::new("ttl")
+                .long("ttl")
+                .value_name("SECONDS")
+                .value_parser(clap::value_parser!(u64))
+                .help("Time to live in seconds")
+                .required(false)
+                .conflicts_with("expires-at"),
+        )
+        .arg(
+            Arg::new("expires-at")
+                .long("expires-at")
+                .value_name("RFC3339")
+                .help("Expiration date in RFC3339 format (e.g. 2026-04-05T12:00:00Z)")
+                .required(false)
+                .conflicts_with("ttl"),
+        )
+        .arg(
+            Arg::new("ip-allow")
+                .long("ip-allow")
+                .value_name("IP_OR_CIDR")
+                .action(Append)
+                .num_args(1..)
+                .help("Allowed source IP or CIDR. Can be used multiple times")
+                .required(false),
+        )
 }
 
 pub(super) async fn create_token(ctx: &CliContext, args: &ArgMatches) -> anyhow::Result<()> {
@@ -66,20 +93,39 @@ pub(super) async fn create_token(ctx: &CliContext, args: &ArgMatches) -> anyhow:
         .unwrap_or_default()
         .map(|s| s.to_string())
         .collect::<Vec<String>>();
+    let ttl = args.get_one::<u64>("ttl").copied();
+    let expires_at = args
+        .get_one::<String>("expires-at")
+        .map(|expires_at| {
+            DateTime::parse_from_rfc3339(expires_at)
+                .map(|ts| ts.with_timezone(&Utc))
+                .map_err(|e| anyhow::anyhow!("invalid --expires-at '{}': {}", expires_at, e))
+        })
+        .transpose()?;
+    let ip_allowlist = args
+        .get_many::<String>("ip-allow")
+        .unwrap_or_default()
+        .map(|s| s.to_string())
+        .collect::<Vec<String>>();
 
     let client: ReductClient = build_client(ctx, &alias_or_url).await?;
     let token = client
-        .create_token(
+        .create_token_with_options(
             &token_name,
-            Permissions {
-                full_access,
-                read: read_buckets,
-                write: write_buckets,
+            TokenCreateOptions {
+                permissions: Permissions {
+                    full_access,
+                    read: read_buckets,
+                    write: write_buckets,
+                },
+                expires_at,
+                ttl,
+                ip_allowlist,
             },
         )
         .await?;
 
-    output!(ctx, "Token '{}' created: {}", token_name, token);
+    output!(ctx, "Token '{}' created: {}", token_name, token.value);
     Ok(())
 }
 
@@ -97,6 +143,10 @@ mod tests {
                 "create",
                 format!("local/{}", token.await).as_str(),
                 "--full-access",
+                "--ttl",
+                "60",
+                "--ip-allow",
+                "127.0.0.1",
                 "--read-bucket",
                 "test",
                 "--write-bucket",
@@ -114,5 +164,23 @@ mod tests {
         let cmd = create_token_cmd();
         let args = cmd.try_get_matches_from(vec!["create", "test"]);
         assert_eq!(args.unwrap_err().to_string(), "error: invalid value 'test' for '<TOKEN_PATH>'\n\nFor more information, try '--help'.\n");
+    }
+
+    #[rstest]
+    fn test_create_token_ttl_expires_conflict() {
+        let cmd = create_token_cmd();
+        let err = cmd
+            .try_get_matches_from(vec![
+                "create",
+                "local/test_token",
+                "--ttl",
+                "60",
+                "--expires-at",
+                "2026-04-05T12:00:00Z",
+            ])
+            .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("cannot be used with '--expires-at <RFC3339>'"));
     }
 }

--- a/src/cmd/token/create.rs
+++ b/src/cmd/token/create.rs
@@ -13,6 +13,35 @@ use clap::ArgAction::{Append, SetTrue};
 use clap::{Arg, ArgMatches, Command};
 use reduct_rs::{Permissions, ReductClient, TokenCreateOptions};
 
+fn parse_simple_duration(input: &str) -> anyhow::Result<u64> {
+    if input.len() < 2 {
+        return Err(anyhow::anyhow!(
+            "invalid duration '{}': expected format like 1h or 2d",
+            input
+        ));
+    }
+
+    let (value, unit) = input.split_at(input.len() - 1);
+    let value = value
+        .parse::<u64>()
+        .map_err(|_| anyhow::anyhow!("invalid duration '{}': numeric part is invalid", input))?;
+
+    let seconds = match unit.to_ascii_lowercase().as_str() {
+        "s" => value,
+        "m" => value.saturating_mul(60),
+        "h" => value.saturating_mul(60 * 60),
+        "d" => value.saturating_mul(60 * 60 * 24),
+        _ => {
+            return Err(anyhow::anyhow!(
+                "invalid duration '{}': use units s, m, h, d",
+                input
+            ))
+        }
+    };
+
+    Ok(seconds)
+}
+
 pub(super) fn create_token_cmd() -> Command {
     Command::new("create")
         .about("Create an access token")
@@ -63,7 +92,15 @@ pub(super) fn create_token_cmd() -> Command {
                 .value_name("RFC3339")
                 .help("Expiration date in RFC3339 format (e.g. 2026-04-05T12:00:00Z)")
                 .required(false)
-                .conflicts_with("ttl"),
+                .conflicts_with_all(["ttl", "expires-in"]),
+        )
+        .arg(
+            Arg::new("expires-in")
+                .long("expires-in")
+                .value_name("DURATION")
+                .help("Relative expiry duration (e.g. 1h, 2d, 30m)")
+                .required(false)
+                .conflicts_with_all(["ttl", "expires-at"]),
         )
         .arg(
             Arg::new("ip-allow")
@@ -102,6 +139,20 @@ pub(super) async fn create_token(ctx: &CliContext, args: &ArgMatches) -> anyhow:
                 .map_err(|e| anyhow::anyhow!("invalid --expires-at '{}': {}", expires_at, e))
         })
         .transpose()?;
+    let expires_at = if expires_at.is_none() {
+        args.get_one::<String>("expires-in")
+            .map(|value| {
+                let seconds = parse_simple_duration(value)?;
+                let seconds = i64::try_from(seconds)
+                    .map_err(|_| anyhow::anyhow!("--expires-in is too large"))?;
+                Utc::now()
+                    .checked_add_signed(chrono::Duration::seconds(seconds))
+                    .ok_or_else(|| anyhow::anyhow!("--expires-in results in invalid timestamp"))
+            })
+            .transpose()?
+    } else {
+        expires_at
+    };
     let ip_allowlist = args
         .get_many::<String>("ip-allow")
         .unwrap_or_default()
@@ -182,5 +233,41 @@ mod tests {
         assert!(err
             .to_string()
             .contains("cannot be used with '--expires-at <RFC3339>'"));
+    }
+
+    #[rstest]
+    #[case("1s", 1)]
+    #[case("30m", 1800)]
+    #[case("1h", 3600)]
+    #[case("2d", 172800)]
+    fn test_parse_simple_duration_ok(#[case] input: &str, #[case] expected: u64) {
+        assert_eq!(parse_simple_duration(input).unwrap(), expected);
+    }
+
+    #[rstest]
+    #[case("")]
+    #[case("1")]
+    #[case("xh")]
+    #[case("10w")]
+    fn test_parse_simple_duration_err(#[case] input: &str) {
+        assert!(parse_simple_duration(input).is_err());
+    }
+
+    #[rstest]
+    fn test_create_token_expires_in_conflicts_with_ttl() {
+        let cmd = create_token_cmd();
+        let err = cmd
+            .try_get_matches_from(vec![
+                "create",
+                "local/test_token",
+                "--ttl",
+                "60",
+                "--expires-in",
+                "1h",
+            ])
+            .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("cannot be used with '--expires-in <DURATION>'"));
     }
 }

--- a/src/cmd/token/ls.rs
+++ b/src/cmd/token/ls.rs
@@ -7,25 +7,112 @@ use crate::cmd::ALIAS_OR_URL_HELP;
 use crate::context::CliContext;
 use crate::io::reduct::build_client;
 use crate::io::std::output;
+use clap::ArgAction::SetTrue;
 use clap::{Arg, ArgMatches, Command};
+use reduct_rs::TokenInfo;
+use tabled::settings::Style;
+use tabled::{Table, Tabled};
 
 pub(super) fn ls_tokens_cmd() -> Command {
-    Command::new("ls").about("List access tokens").arg(
-        Arg::new("ALIAS_OR_URL")
-            .help(ALIAS_OR_URL_HELP)
-            .required(true),
-    )
+    Command::new("ls")
+        .about("List access tokens")
+        .arg(
+            Arg::new("ALIAS_OR_URL")
+                .help(ALIAS_OR_URL_HELP)
+                .required(true),
+        )
+        .arg(
+            Arg::new("full")
+                .long("full")
+                .short('f')
+                .action(SetTrue)
+                .help("Show detailed token information")
+                .required(false),
+        )
 }
 
 pub(super) async fn ls_tokens(ctx: &CliContext, args: &ArgMatches) -> anyhow::Result<()> {
     let alias_or_url = args.get_one::<String>("ALIAS_OR_URL").unwrap();
     let client = build_client(ctx, alias_or_url).await?;
 
-    let token_list = client.list_tokens().await?;
+    let token_list = client.list_tokens_info().await?;
+    if args.get_flag("full") {
+        print_full_list(ctx, token_list);
+    } else {
+        print_list(ctx, token_list);
+    }
+
+    Ok(())
+}
+
+fn print_list(ctx: &CliContext, token_list: Vec<TokenInfo>) {
     for token in token_list {
         output!(ctx, "{}", token.name);
     }
-    Ok(())
+}
+
+#[derive(Tabled)]
+struct TokenTable {
+    #[tabled(rename = "Name")]
+    name: String,
+    #[tabled(rename = "Provisioned")]
+    provisioned: String,
+    #[tabled(rename = "Expired")]
+    expired: String,
+    #[tabled(rename = "Expires At (UTC)")]
+    expires_at: String,
+    #[tabled(rename = "TTL (s)")]
+    ttl: String,
+    #[tabled(rename = "Last Access (UTC)")]
+    last_access: String,
+    #[tabled(rename = "IP Allowlist")]
+    ip_allowlist: String,
+}
+
+impl From<TokenInfo> for TokenTable {
+    fn from(token: TokenInfo) -> Self {
+        Self {
+            name: token.name,
+            provisioned: if token.is_provisioned {
+                "✓".to_string()
+            } else {
+                "-".to_string()
+            },
+            expired: if token.is_expired {
+                "✓".to_string()
+            } else {
+                "-".to_string()
+            },
+            expires_at: token
+                .expires_at
+                .map(|ts| ts.to_rfc3339())
+                .unwrap_or("-".to_string()),
+            ttl: token
+                .ttl
+                .map(|ttl| ttl.to_string())
+                .unwrap_or("-".to_string()),
+            last_access: token
+                .last_access
+                .map(|ts| ts.to_rfc3339())
+                .unwrap_or("-".to_string()),
+            ip_allowlist: if token.ip_allowlist.is_empty() {
+                "-".to_string()
+            } else {
+                token.ip_allowlist.join(", ")
+            },
+        }
+    }
+}
+
+fn print_full_list(ctx: &CliContext, token_list: Vec<TokenInfo>) {
+    if token_list.is_empty() {
+        return;
+    }
+
+    let table = Table::new(token_list.into_iter().map(TokenTable::from))
+        .with(Style::markdown())
+        .to_string();
+    output!(ctx, "{}", table);
 }
 
 #[cfg(test)]
@@ -52,5 +139,25 @@ mod tests {
             context.stdout().history(),
             vec!["init-token", token.as_str()]
         );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_ls_tokens_full(context: CliContext, #[future] token: String) {
+        let token = token.await;
+        let client = build_client(&context, "local").await.unwrap();
+        client
+            .create_token(&token, Permissions::default())
+            .await
+            .unwrap();
+        let token_list = client.list_tokens_info().await.unwrap();
+
+        let args = ls_tokens_cmd().get_matches_from(vec!["ls", "local", "--full"]);
+        ls_tokens(&context, &args).await.unwrap();
+
+        let expected = Table::new(token_list.into_iter().map(TokenTable::from))
+            .with(Style::markdown())
+            .to_string();
+        assert_eq!(context.stdout().history(), vec![expected]);
     }
 }

--- a/src/cmd/token/ls.rs
+++ b/src/cmd/token/ls.rs
@@ -7,6 +7,7 @@ use crate::cmd::ALIAS_OR_URL_HELP;
 use crate::context::CliContext;
 use crate::io::reduct::build_client;
 use crate::io::std::output;
+use chrono::{DateTime, SecondsFormat, Utc};
 use clap::ArgAction::SetTrue;
 use clap::{Arg, ArgMatches, Command};
 use reduct_rs::TokenInfo;
@@ -57,8 +58,8 @@ struct TokenTable {
     name: String,
     #[tabled(rename = "Provisioned")]
     provisioned: String,
-    #[tabled(rename = "Expired")]
-    expired: String,
+    #[tabled(rename = "Status")]
+    status: String,
     #[tabled(rename = "Expires At (UTC)")]
     expires_at: String,
     #[tabled(rename = "TTL (s)")]
@@ -71,6 +72,9 @@ struct TokenTable {
 
 impl From<TokenInfo> for TokenTable {
     fn from(token: TokenInfo) -> Self {
+        let format_ts =
+            |ts: DateTime<Utc>| -> String { ts.to_rfc3339_opts(SecondsFormat::Secs, true) };
+
         Self {
             name: token.name,
             provisioned: if token.is_provisioned {
@@ -78,23 +82,17 @@ impl From<TokenInfo> for TokenTable {
             } else {
                 "-".to_string()
             },
-            expired: if token.is_expired {
-                "✓".to_string()
+            status: if token.is_expired {
+                "❌ Expired".to_string()
             } else {
-                "-".to_string()
+                "✅ Valid".to_string()
             },
-            expires_at: token
-                .expires_at
-                .map(|ts| ts.to_rfc3339())
-                .unwrap_or("-".to_string()),
+            expires_at: token.expires_at.map(format_ts).unwrap_or("-".to_string()),
             ttl: token
                 .ttl
                 .map(|ttl| ttl.to_string())
                 .unwrap_or("-".to_string()),
-            last_access: token
-                .last_access
-                .map(|ts| ts.to_rfc3339())
-                .unwrap_or("-".to_string()),
+            last_access: token.last_access.map(format_ts).unwrap_or("-".to_string()),
             ip_allowlist: if token.ip_allowlist.is_empty() {
                 "-".to_string()
             } else {

--- a/src/cmd/token/rm.rs
+++ b/src/cmd/token/rm.rs
@@ -65,7 +65,6 @@ pub(super) async fn rm_token(ctx: &CliContext, args: &ArgMatches) -> anyhow::Res
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cmd::token::create::create_token_cmd;
     use crate::context::tests::{context, token};
     use reduct_rs::ErrorCode;
     use rstest::*;
@@ -95,8 +94,8 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn test_rm_token_bad_path() {
-        let cmd = create_token_cmd();
-        let args = cmd.try_get_matches_from(vec!["create", "test"]);
+        let cmd = rm_token_cmd();
+        let args = cmd.try_get_matches_from(vec!["rm", "test"]);
         assert_eq!(args.unwrap_err().to_string(), "error: invalid value 'test' for '<TOKEN_PATH>'\n\nFor more information, try '--help'.\n");
     }
 }

--- a/src/cmd/token/rotate.rs
+++ b/src/cmd/token/rotate.rs
@@ -1,0 +1,79 @@
+// Copyright 2026 ReductStore
+// This Source Code Form is subject to the terms of the Mozilla Public
+//    License, v. 2.0. If a copy of the MPL was not distributed with this
+//    file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use crate::cmd::RESOURCE_PATH_HELP;
+use crate::context::CliContext;
+use crate::io::reduct::build_client;
+use crate::io::std::output;
+use crate::parse::{Resource, ResourcePathParser};
+use clap::{Arg, ArgMatches, Command};
+
+pub(super) fn rotate_token_cmd() -> Command {
+    Command::new("rotate")
+        .about("Rotate an access token value")
+        .arg(
+            Arg::new("TOKEN_PATH")
+                .help(RESOURCE_PATH_HELP)
+                .value_parser(ResourcePathParser::new())
+                .required(true),
+        )
+        .arg_required_else_help(true)
+}
+
+pub(super) async fn rotate_token(ctx: &CliContext, args: &ArgMatches) -> anyhow::Result<()> {
+    let (alias_or_url, token_name) = args
+        .get_one::<Resource>("TOKEN_PATH")
+        .unwrap()
+        .clone()
+        .pair()?;
+
+    let client = build_client(ctx, &alias_or_url).await?;
+    let token = client.rotate_token(&token_name).await?;
+    output!(ctx, "Token '{}' rotated: {}", token_name, token.value);
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::tests::{context, token};
+    use reduct_rs::{ErrorCode, Permissions};
+    use rstest::*;
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_rotate_token(context: CliContext, #[future] token: String) {
+        let token = token.await;
+        let client = build_client(&context, "local").await.unwrap();
+        client
+            .create_token(&token, Permissions::default())
+            .await
+            .unwrap();
+
+        let args = rotate_token_cmd()
+            .get_matches_from(vec!["rotate", format!("local/{}", token).as_str()]);
+        if let Err(err) = rotate_token(&context, &args).await {
+            if let Some(err) = err.downcast_ref::<reduct_rs::ReductError>() {
+                if err.status() == ErrorCode::MethodNotAllowed {
+                    return;
+                }
+            }
+            panic!("unexpected error: {err}");
+        }
+
+        assert!(
+            context.stdout().history()[0].starts_with("Token 'test_token' rotated: test_token-")
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_rotate_token_bad_path() {
+        let cmd = rotate_token_cmd();
+        let args = cmd.try_get_matches_from(vec!["rotate", "test"]);
+        assert_eq!(args.unwrap_err().to_string(), "error: invalid value 'test' for '<TOKEN_PATH>'\n\nFor more information, try '--help'.\n");
+    }
+}

--- a/src/cmd/token/show.rs
+++ b/src/cmd/token/show.rs
@@ -8,6 +8,7 @@ use crate::context::CliContext;
 use crate::io::reduct::build_client;
 use crate::io::std::output;
 use crate::parse::{Resource, ResourcePathParser};
+use chrono::SecondsFormat;
 
 use clap::{Arg, ArgMatches, Command};
 
@@ -38,13 +39,21 @@ pub(super) async fn show_token(ctx: &CliContext, args: &ArgMatches) -> anyhow::R
     output!(ctx, "Token: {}", token_name);
     output!(ctx, "Created: {}", token.created_at.date_naive());
     output!(ctx, "Provisioned: {}", bool_icon(token.is_provisioned));
-    output!(ctx, "Expired: {}", bool_icon(token.is_expired));
+    output!(
+        ctx,
+        "Status: {}",
+        if token.is_expired {
+            "❌ Expired"
+        } else {
+            "✅ Valid"
+        }
+    );
     output!(
         ctx,
         "Expires At: {}",
         token
             .expires_at
-            .map(|ts| ts.to_rfc3339())
+            .map(|ts| ts.to_rfc3339_opts(SecondsFormat::Secs, true))
             .unwrap_or("-".to_string())
     );
     output!(
@@ -60,7 +69,7 @@ pub(super) async fn show_token(ctx: &CliContext, args: &ArgMatches) -> anyhow::R
         "Last Access: {}",
         token
             .last_access
-            .map(|ts| ts.to_rfc3339())
+            .map(|ts| ts.to_rfc3339_opts(SecondsFormat::Secs, true))
             .unwrap_or("-".to_string())
     );
     output!(ctx, "IP Allowlist: {:?}", token.ip_allowlist);
@@ -100,7 +109,7 @@ mod tests {
         let created = history[1].strip_prefix("Created: ").unwrap();
         assert_eq!(created.len(), 10);
         assert_eq!(context.stdout().history()[2], "Provisioned: -");
-        assert_eq!(context.stdout().history()[3], "Expired: -");
+        assert_eq!(context.stdout().history()[3], "Status: ✅ Valid");
         assert_eq!(context.stdout().history()[4], "Expires At: -");
         assert_eq!(context.stdout().history()[5], "TTL: -");
         assert_eq!(context.stdout().history()[6], "Last Access: -");

--- a/src/cmd/token/show.rs
+++ b/src/cmd/token/show.rs
@@ -31,15 +31,41 @@ pub(super) async fn show_token(ctx: &CliContext, args: &ArgMatches) -> anyhow::R
         .pair()?;
 
     let client = build_client(ctx, &alias_or_url).await?;
-    let token = client.get_token(&token_name).await?;
+    let token = client.get_token_info(&token_name).await?;
 
     let bool_icon = |value: bool| if value { "✓" } else { "-" };
 
     output!(ctx, "Token: {}", token_name);
     output!(ctx, "Created: {}", token.created_at.date_naive());
     output!(ctx, "Provisioned: {}", bool_icon(token.is_provisioned));
+    output!(ctx, "Expired: {}", bool_icon(token.is_expired));
+    output!(
+        ctx,
+        "Expires At: {}",
+        token
+            .expires_at
+            .map(|ts| ts.to_rfc3339())
+            .unwrap_or("-".to_string())
+    );
+    output!(
+        ctx,
+        "TTL: {}",
+        token
+            .ttl
+            .map(|ttl| ttl.to_string())
+            .unwrap_or("-".to_string())
+    );
+    output!(
+        ctx,
+        "Last Access: {}",
+        token
+            .last_access
+            .map(|ts| ts.to_rfc3339())
+            .unwrap_or("-".to_string())
+    );
+    output!(ctx, "IP Allowlist: {:?}", token.ip_allowlist);
 
-    let permissions = token.permissions.unwrap();
+    let permissions = token.permissions.unwrap_or_default();
     output!(ctx, "Full Access: {}", bool_icon(permissions.full_access));
     output!(ctx, "Read Buckets: {:?}", permissions.read);
     output!(ctx, "Write Buckets: {:?}", permissions.write);
@@ -50,7 +76,6 @@ pub(super) async fn show_token(ctx: &CliContext, args: &ArgMatches) -> anyhow::R
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cmd::token::create::create_token_cmd;
     use crate::context::tests::{context, token};
     use reduct_rs::Permissions;
     use rstest::*;
@@ -75,15 +100,20 @@ mod tests {
         let created = history[1].strip_prefix("Created: ").unwrap();
         assert_eq!(created.len(), 10);
         assert_eq!(context.stdout().history()[2], "Provisioned: -");
-        assert_eq!(context.stdout().history()[3], "Full Access: -");
-        assert_eq!(context.stdout().history()[4], "Read Buckets: []");
-        assert_eq!(context.stdout().history()[5], "Write Buckets: []");
+        assert_eq!(context.stdout().history()[3], "Expired: -");
+        assert_eq!(context.stdout().history()[4], "Expires At: -");
+        assert_eq!(context.stdout().history()[5], "TTL: -");
+        assert_eq!(context.stdout().history()[6], "Last Access: -");
+        assert_eq!(context.stdout().history()[7], "IP Allowlist: []");
+        assert_eq!(context.stdout().history()[8], "Full Access: -");
+        assert_eq!(context.stdout().history()[9], "Read Buckets: []");
+        assert_eq!(context.stdout().history()[10], "Write Buckets: []");
     }
 
     #[rstest]
     #[tokio::test]
     async fn test_show_token_bad_path() {
-        let cmd = create_token_cmd();
+        let cmd = show_token_cmd();
         let args = cmd.try_get_matches_from(vec!["show", "test"]);
         assert_eq!(args.unwrap_err().to_string(), "error: invalid value 'test' for '<TOKEN_PATH>'\n\nFor more information, try '--help'.\n");
     }


### PR DESCRIPTION
Closes #166

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

- Added token API v2 support in CLI token commands.
- Added `token rotate` subcommand.
- Extended `token create` with `--ttl`, `--expires-at`, `--expires-in`, and `--ip-allow`.
- Updated `token show` to display extended token metadata.
- Updated `token ls --full` to print a table with status, expiry, TTL, last access, and IP allowlist.
- Added/updated tests for token command parsing and behavior.

### Related issues

- https://github.com/reductstore/reduct-cli/issues/166
- Parent: https://github.com/reductstore/reductstore/issues/1088

### Does this PR introduce a breaking change?

No.

### Other information:

`cargo fmt`

`RS_API_TOKEN=TOKEN cargo test cmd::token:: -- --test-threads=1`
