### PR TITLE
Fix reduct-rs 1.19 token command compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.11.0 - 2026-04-09
+
 ### Added
 
 - Add `attachment write`, `attachment ls`, `attachment read`, and `attachment rm` commands for entry attachments, [PR-184](https://github.com/reductstore/reduct-cli/pull/184)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1487,9 +1487,9 @@ dependencies = [
 
 [[package]]
 name = "reduct-base"
-version = "1.19.0"
+version = "1.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f788e536efd91cd374fc93d143f829a962763cc058fc14970962a5b14881f87"
+checksum = "d2da32b8ad3a89caeb265138c36c095c62458688421c3ec3ea7badc88e64f12a"
 dependencies = [
  "bytes",
  "chrono",
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "reduct-cli"
-version = "0.10.2"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1536,7 +1536,8 @@ dependencies = [
 [[package]]
 name = "reduct-rs"
 version = "1.19.0"
-source = "git+https://github.com/reductstore/reduct-rs?branch=main#360d6641abbee4d6e7c4847d071222f0efbdc1f1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26479d997d49e72e8ee10dfd79fceea2e7d5dc5e84e1f9bf2c547abf41b4d15a"
 dependencies = [
  "async-channel",
  "async-stream",
@@ -2130,9 +2131,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -2203,9 +2204,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.10+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82418ca169e235e6c399a84e395ab6debeb3bc90edc959bf0f48647c6a32d1b"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
  "toml_datetime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reduct-cli"
-version = "0.10.2"
+version = "0.11.0"
 edition = "2021"
 authors = ["Alexey Timin <atimin@reduct.store>"]
 rust-version = "1.89.0"
@@ -14,7 +14,7 @@ documentation = "https://reduct.store/docs/guides"
 description = "A CLI client for ReductStore written in Rust"
 
 [dependencies]
-reduct-rs =  { version = "1.19.0", git = "https://github.com/reductstore/reduct-rs", branch = "main" }
+reduct-rs =  { version = "1.19.0"}
 clap = { version = "4.5.53", features = ["cargo"] }
 dirs = "6.0.0"
 toml = "1.0.6"

--- a/src/cmd/token/create.rs
+++ b/src/cmd/token/create.rs
@@ -11,7 +11,8 @@ use crate::parse::{Resource, ResourcePathParser};
 use chrono::{DateTime, Utc};
 use clap::ArgAction::{Append, SetTrue};
 use clap::{Arg, ArgMatches, Command};
-use reduct_rs::{Permissions, ReductClient, TokenCreateOptions};
+use reduct_rs::{Permissions, ReductClient};
+use std::time::Duration;
 
 fn parse_simple_duration(input: &str) -> anyhow::Result<u64> {
     if input.len() < 2 {
@@ -80,11 +81,9 @@ pub(super) fn create_token_cmd() -> Command {
         .arg(
             Arg::new("ttl")
                 .long("ttl")
-                .value_name("SECONDS")
-                .value_parser(clap::value_parser!(u64))
-                .help("Time to live in seconds")
-                .required(false)
-                .conflicts_with("expires-at"),
+                .value_name("DURATION")
+                .help("Inactivity TTL duration (e.g. 1h, 2d, 30m)")
+                .required(false),
         )
         .arg(
             Arg::new("expires-at")
@@ -92,7 +91,7 @@ pub(super) fn create_token_cmd() -> Command {
                 .value_name("RFC3339")
                 .help("Expiration date in RFC3339 format (e.g. 2026-04-05T12:00:00Z)")
                 .required(false)
-                .conflicts_with_all(["ttl", "expires-in"]),
+                .conflicts_with("expires-in"),
         )
         .arg(
             Arg::new("expires-in")
@@ -100,7 +99,7 @@ pub(super) fn create_token_cmd() -> Command {
                 .value_name("DURATION")
                 .help("Relative expiry duration (e.g. 1h, 2d, 30m)")
                 .required(false)
-                .conflicts_with_all(["ttl", "expires-at"]),
+                .conflicts_with("expires-at"),
         )
         .arg(
             Arg::new("ip-allow")
@@ -130,7 +129,14 @@ pub(super) async fn create_token(ctx: &CliContext, args: &ArgMatches) -> anyhow:
         .unwrap_or_default()
         .map(|s| s.to_string())
         .collect::<Vec<String>>();
-    let ttl = args.get_one::<u64>("ttl").copied();
+    let ttl = args
+        .get_one::<String>("ttl")
+        .map(|value| {
+            parse_simple_duration(value)
+                .map(Duration::from_secs)
+                .map_err(|e| anyhow::anyhow!("invalid --ttl '{}': {}", value, e))
+        })
+        .transpose()?;
     let expires_at = args
         .get_one::<String>("expires-at")
         .map(|expires_at| {
@@ -160,21 +166,26 @@ pub(super) async fn create_token(ctx: &CliContext, args: &ArgMatches) -> anyhow:
         .collect::<Vec<String>>();
 
     let client: ReductClient = build_client(ctx, &alias_or_url).await?;
-    let token = client
-        .create_token_with_options(
-            &token_name,
-            TokenCreateOptions {
-                permissions: Permissions {
-                    full_access,
-                    read: read_buckets,
-                    write: write_buckets,
-                },
-                expires_at,
-                ttl,
-                ip_allowlist,
-            },
-        )
-        .await?;
+    let permissions = Permissions {
+        full_access,
+        read: read_buckets,
+        write: write_buckets,
+    };
+
+    let mut create_token = client
+        .create_token_builder(&token_name)
+        .permissions(permissions)
+        .ip_allowlist(ip_allowlist);
+
+    if let Some(expires_at) = expires_at {
+        create_token = create_token.expires_at(expires_at);
+    }
+
+    if let Some(ttl) = ttl {
+        create_token = create_token.ttl(ttl);
+    }
+
+    let token = create_token.send().await?;
 
     output!(ctx, "Token '{}' created: {}", token_name, token.value);
     Ok(())
@@ -195,7 +206,7 @@ mod tests {
                 format!("local/{}", token.await).as_str(),
                 "--full-access",
                 "--ttl",
-                "60",
+                "60s",
                 "--ip-allow",
                 "127.0.0.1",
                 "--read-bucket",
@@ -218,21 +229,26 @@ mod tests {
     }
 
     #[rstest]
-    fn test_create_token_ttl_expires_conflict() {
+    fn test_create_token_ttl_and_expires_at_allowed() {
         let cmd = create_token_cmd();
-        let err = cmd
+        let args = cmd
             .try_get_matches_from(vec![
                 "create",
                 "local/test_token",
                 "--ttl",
-                "60",
+                "60s",
                 "--expires-at",
                 "2026-04-05T12:00:00Z",
             ])
-            .unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("cannot be used with '--expires-at <RFC3339>'"));
+            .unwrap();
+        assert_eq!(
+            args.get_one::<String>("ttl").map(String::as_str),
+            Some("60s")
+        );
+        assert_eq!(
+            args.get_one::<String>("expires-at").map(String::as_str),
+            Some("2026-04-05T12:00:00Z")
+        );
     }
 
     #[rstest]
@@ -254,14 +270,37 @@ mod tests {
     }
 
     #[rstest]
-    fn test_create_token_expires_in_conflicts_with_ttl() {
+    fn test_create_token_ttl_and_expires_in_allowed() {
+        let cmd = create_token_cmd();
+        let args = cmd
+            .try_get_matches_from(vec![
+                "create",
+                "local/test_token",
+                "--ttl",
+                "60s",
+                "--expires-in",
+                "1h",
+            ])
+            .unwrap();
+        assert_eq!(
+            args.get_one::<String>("ttl").map(String::as_str),
+            Some("60s")
+        );
+        assert_eq!(
+            args.get_one::<String>("expires-in").map(String::as_str),
+            Some("1h")
+        );
+    }
+
+    #[rstest]
+    fn test_create_token_expires_in_conflicts_with_expires_at() {
         let cmd = create_token_cmd();
         let err = cmd
             .try_get_matches_from(vec![
                 "create",
                 "local/test_token",
-                "--ttl",
-                "60",
+                "--expires-at",
+                "2026-04-05T12:00:00Z",
                 "--expires-in",
                 "1h",
             ])

--- a/src/cmd/token/create.rs
+++ b/src/cmd/token/create.rs
@@ -265,6 +265,7 @@ mod tests {
     #[case("1")]
     #[case("xh")]
     #[case("10w")]
+    #[case("1y")]
     fn test_parse_simple_duration_err(#[case] input: &str) {
         assert!(parse_simple_duration(input).is_err());
     }

--- a/src/cmd/token/ls.rs
+++ b/src/cmd/token/ls.rs
@@ -10,7 +10,7 @@ use crate::io::std::output;
 use chrono::{DateTime, SecondsFormat, Utc};
 use clap::ArgAction::SetTrue;
 use clap::{Arg, ArgMatches, Command};
-use reduct_rs::TokenInfo;
+use reduct_rs::Token;
 use tabled::settings::Style;
 use tabled::{Table, Tabled};
 
@@ -36,7 +36,7 @@ pub(super) async fn ls_tokens(ctx: &CliContext, args: &ArgMatches) -> anyhow::Re
     let alias_or_url = args.get_one::<String>("ALIAS_OR_URL").unwrap();
     let client = build_client(ctx, alias_or_url).await?;
 
-    let token_list = client.list_tokens_info().await?;
+    let token_list = client.list_tokens().await?;
     if args.get_flag("full") {
         print_full_list(ctx, token_list);
     } else {
@@ -46,7 +46,7 @@ pub(super) async fn ls_tokens(ctx: &CliContext, args: &ArgMatches) -> anyhow::Re
     Ok(())
 }
 
-fn print_list(ctx: &CliContext, token_list: Vec<TokenInfo>) {
+fn print_list(ctx: &CliContext, token_list: Vec<Token>) {
     for token in token_list {
         output!(ctx, "{}", token.name);
     }
@@ -70,8 +70,8 @@ struct TokenTable {
     ip_allowlist: String,
 }
 
-impl From<TokenInfo> for TokenTable {
-    fn from(token: TokenInfo) -> Self {
+impl From<Token> for TokenTable {
+    fn from(token: Token) -> Self {
         let format_ts =
             |ts: DateTime<Utc>| -> String { ts.to_rfc3339_opts(SecondsFormat::Secs, true) };
 
@@ -102,7 +102,7 @@ impl From<TokenInfo> for TokenTable {
     }
 }
 
-fn print_full_list(ctx: &CliContext, token_list: Vec<TokenInfo>) {
+fn print_full_list(ctx: &CliContext, token_list: Vec<Token>) {
     if token_list.is_empty() {
         return;
     }
@@ -148,7 +148,7 @@ mod tests {
             .create_token(&token, Permissions::default())
             .await
             .unwrap();
-        let token_list = client.list_tokens_info().await.unwrap();
+        let token_list = client.list_tokens().await.unwrap();
 
         let args = ls_tokens_cmd().get_matches_from(vec!["ls", "local", "--full"]);
         ls_tokens(&context, &args).await.unwrap();

--- a/src/cmd/token/show.rs
+++ b/src/cmd/token/show.rs
@@ -32,7 +32,7 @@ pub(super) async fn show_token(ctx: &CliContext, args: &ArgMatches) -> anyhow::R
         .pair()?;
 
     let client = build_client(ctx, &alias_or_url).await?;
-    let token = client.get_token_info(&token_name).await?;
+    let token = client.get_token(&token_name).await?;
 
     let bool_icon = |value: bool| if value { "✓" } else { "-" };
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

- switched the CLI to the released `reduct-rs` 1.19.0 crate instead of the git main dependency
- fixed token command build breakage by migrating `token create` to the new builder API and updating `token ls/show` to the new token methods
- aligned token TTL parsing with the new token API by accepting duration values for `--ttl` and allowing it to be combined with `--expires-at` or `--expires-in`
- added parser coverage for invalid duration inputs including `1y`

### Related issues

N/A

### Does this PR introduce a breaking change?

The `token create --ttl` flag now expects a duration value such as `60s`, `30m`, `1h`, or `2d` instead of a bare integer.

### Other information:

Validation performed:
- `cargo build`
- `cargo test cmd::token::create::tests:: -- --nocapture` (parser coverage passed; the live token creation test still requires a ReductStore instance on `localhost:8383`)
