### PR TITLE
Add Snap package and publish workflow for reduct-cli

### DIFF
--- a/.github/actions/snap-release/action.yml
+++ b/.github/actions/snap-release/action.yml
@@ -1,0 +1,51 @@
+name: Build Snap Package
+description: Builds a snap package from prebuilt reduct-cli binary artifacts.
+inputs:
+  arch:
+    description: Architecture (amd64, arm64)
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Resolve binary artifact
+      shell: bash
+      run: |
+        set -euo pipefail
+        case "${{ inputs.arch }}" in
+          amd64)
+            target_triple="x86_64-unknown-linux-gnu"
+            ;;
+          arm64)
+            target_triple="aarch64-unknown-linux-gnu"
+            ;;
+          *)
+            echo "Unsupported architecture: ${{ inputs.arch }}"
+            exit 1
+            ;;
+        esac
+
+        echo "TARGET_TRIPLE=${target_triple}" >> "$GITHUB_ENV"
+        echo "BINARY_ARTIFACT=reduct-cli-${target_triple}" >> "$GITHUB_ENV"
+
+    - name: Download binary artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ env.BINARY_ARTIFACT }}
+        path: .snap-build/bin
+
+    - name: Prepare snap payload files
+      shell: bash
+      run: |
+        set -euo pipefail
+        chmod +x .snap-build/bin/reduct-cli
+
+    - uses: snapcore/action-build@v1
+      id: build-snap
+      with:
+        snapcraft-args: "pack --verbose --build-for=${{ inputs.arch }}"
+
+    - name: Save snap name in environment variable
+      shell: bash
+      run: |
+        set -euo pipefail
+        echo "SNAP_NAME=$(ls *.snap | grep ${{ inputs.arch }})" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,3 +245,28 @@ jobs:
           asset_path: /tmp/reduct-cli.${{ matrix.target }}.zip
           asset_name: reduct-cli.${{ matrix.target }}.zip
           asset_content_type: application/zip
+
+  snap_release:
+    name: Build and Publish Snap Package
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [ amd64, arm64 ]
+    needs:
+      - build
+      - cli_tests
+      - check_tag
+    if: github.event_name != 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/snap-release
+        with:
+          arch: ${{ matrix.arch }}
+
+      - name: Publish snap package
+        uses: snapcore/action-publish@master
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_LOGIN }}
+        with:
+          snap: ${{ env.SNAP_NAME }}
+          release: ${{ startsWith(github.ref, 'refs/tags/') && 'stable' || 'edge' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Add Snap package metadata and CI publish workflow for amd64/arm64 builds, [PR-204](https://github.com/reductstore/reduct-cli/pull/204)
+
 ## 0.11.0 - 2026-04-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ blob data.
 cargo install reduct-cli
 ```
 
+### From Snap
+
+```bash
+sudo snap install reduct-cli
+```
+
 ### From pre-built binaries
 
 You can also install `reduct-cli` from the latest release binaries.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,41 @@
+title: Reduct CLI
+name: reduct-cli
+base: core24
+version: git
+summary: Command-line client for ReductStore
+
+description: |
+  Reduct CLI is the official command-line client for ReductStore.
+  Use it to manage buckets, tokens, and replication, inspect server health,
+  and copy or mirror time-series blob data between local paths and ReductStore instances.
+
+contact: info@reduct.store
+issues: https://github.com/reductstore/reduct-cli/issues
+source-code: https://github.com/reductstore/reduct-cli
+website: https://www.reduct.store
+license: MPL-2.0
+confinement: strict
+grade: stable
+
+platforms:
+  amd64:
+    build-on: [amd64]
+    build-for: [amd64]
+  arm64:
+    build-on: [amd64]
+    build-for: [arm64]
+
+parts:
+  reduct-cli:
+    plugin: dump
+    source: .snap-build/bin
+    organize:
+      reduct-cli: bin/reduct-cli
+
+apps:
+  reduct-cli:
+    command: bin/reduct-cli
+    plugs:
+      - network
+      - home
+      - removable-media


### PR DESCRIPTION
Closes #194

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature / CI enhancement

### What was changed?

- Added Snap packaging metadata in `snap/snapcraft.yaml` for `reduct-cli` (strict confinement, amd64 + arm64).
- Added composite GitHub Action `.github/actions/snap-release/action.yml` to:
  - map arch → target triple,
  - download prebuilt release artifacts,
  - build Snap package via `snapcore/action-build@v1`.
- Extended CI workflow with `snap_release` job to build and publish snaps to:
  - `edge` channel for branch pushes,
  - `stable` channel for tag builds.
- Updated README with Snap installation instructions (`sudo snap install reduct-cli`).

### Related issues

- https://github.com/reductstore/reduct-cli/issues/194

### Does this PR introduce a breaking change?

No.

### Other information:

- Implementation follows the same packaging approach already used in `reductstore` and `reduct-bridge` repositories.
