### PR TITLE
fix(ci): use correct secret for Snap publish step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,7 +266,7 @@ jobs:
       - name: Publish snap package
         uses: snapcore/action-publish@master
         env:
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_LOGIN }}
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         with:
           snap: ${{ env.SNAP_NAME }}
           release: ${{ startsWith(github.ref, 'refs/tags/') && 'stable' || 'edge' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add Snap package metadata and CI publish workflow for amd64/arm64 builds, [PR-204](https://github.com/reductstore/reduct-cli/pull/204)
 
+### Fixed
+
+- Fix Snap publish credentials env mapping in CI workflow (`SNAPCRAFT_STORE_CREDENTIALS` secret), [PR-205](https://github.com/reductstore/reduct-cli/pull/205)
+
 ## 0.11.0 - 2026-04-09
 
 ### Added


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix (CI workflow)

### What was changed?

- Fixed Snap publish credentials mapping in `.github/workflows/ci.yml`.
- Replaced:
  - `SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_LOGIN }}`
- With:
  - `SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}`

This resolves `login_data is empty` during `snapcore/action-publish` in CI.

### Related issues

- Failing CI run on `main`: 24390504522 (2026-04-14)

### Does this PR introduce a breaking change?

No.

### Other information:

Scope is intentionally minimal (single-line secret reference fix) to restore Snap publishing.
