### PR TITLE
fix(cp): report partial copy when all entries end with errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.11.1 - 2026-04-22
+
 ### Added
 
 - Add Snap package metadata and CI publish workflow for amd64/arm64 builds, [PR-204](https://github.com/reductstore/reduct-cli/pull/204)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Improve `cp` compatibility and reporting: handle older-source attachment API (`MethodNotAllowed`), track copied/skipped counters (including per-entry skipped and error tree output), and keep failures in progress output, [PR-208](https://github.com/reductstore/reduct-cli/pull/208)
 - Fix Snap publish credentials env mapping in CI workflow (`SNAPCRAFT_STORE_CREDENTIALS` secret), [PR-205](https://github.com/reductstore/reduct-cli/pull/205)
 
 ## 0.11.0 - 2026-04-09

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "reduct-cli"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reduct-cli"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 authors = ["Alexey Timin <atimin@reduct.store>"]
 rust-version = "1.89.0"

--- a/src/cmd/cp/b2b.rs
+++ b/src/cmd/cp/b2b.rs
@@ -44,25 +44,13 @@ impl CopyVisitor for CopyToBucketVisitor {
 
             Ok(result)
         } else {
-            // Write records one-by-one for better compatibility across server versions.
-            let mut result: BTreeMap<u64, ReductError> = BTreeMap::new();
-            for record in records {
-                let timestamp = record.timestamp_us();
-                let res = self
-                    .dst_bucket
-                    .write_record(entry_name)
-                    .timestamp_us(record.timestamp_us())
-                    .labels(record.labels().clone())
-                    .content_type(record.content_type())
-                    .content_length(record.content_length() as u64)
-                    .stream(record.stream_bytes())
-                    .send()
-                    .await;
-                if let Err(err) = res {
-                    result.insert(timestamp, err);
-                }
-            }
-            Ok(result)
+            let errors = self
+                .dst_bucket
+                .write_batch(entry_name)
+                .add_records(records)
+                .send()
+                .await?;
+            Ok(errors.into_iter().collect())
         }
     }
 

--- a/src/cmd/cp/b2b.rs
+++ b/src/cmd/cp/b2b.rs
@@ -39,9 +39,7 @@ impl CopyVisitor for CopyToBucketVisitor {
                 .send()
                 .await;
             if let Err(err) = res {
-                if err.status() != ErrorCode::Conflict {
-                    result.insert(timestamp, err);
-                }
+                result.insert(timestamp, err);
             }
 
             Ok(result)
@@ -52,12 +50,7 @@ impl CopyVisitor for CopyToBucketVisitor {
                 .add_records(records)
                 .send()
                 .await?;
-            let errors: BTreeMap<u64, ReductError> = errors
-                .into_iter()
-                .filter(|(_, err)| err.status() != ErrorCode::Conflict)
-                .collect();
-
-            Ok(errors)
+            Ok(errors.into_iter().collect())
         }
     }
 

--- a/src/cmd/cp/b2b.rs
+++ b/src/cmd/cp/b2b.rs
@@ -44,13 +44,25 @@ impl CopyVisitor for CopyToBucketVisitor {
 
             Ok(result)
         } else {
-            let errors = self
-                .dst_bucket
-                .write_batch(entry_name)
-                .add_records(records)
-                .send()
-                .await?;
-            Ok(errors.into_iter().collect())
+            // Write records one-by-one for better compatibility across server versions.
+            let mut result: BTreeMap<u64, ReductError> = BTreeMap::new();
+            for record in records {
+                let timestamp = record.timestamp_us();
+                let res = self
+                    .dst_bucket
+                    .write_record(entry_name)
+                    .timestamp_us(record.timestamp_us())
+                    .labels(record.labels().clone())
+                    .content_type(record.content_type())
+                    .content_length(record.content_length() as u64)
+                    .stream(record.stream_bytes())
+                    .send()
+                    .await;
+                if let Err(err) = res {
+                    result.insert(timestamp, err);
+                }
+            }
+            Ok(result)
         }
     }
 

--- a/src/cmd/cp/helpers.rs
+++ b/src/cmd/cp/helpers.rs
@@ -85,6 +85,7 @@ pub(super) struct BucketProgress {
     progress_metric: ProgressMetric,
     entry_stats: HashMap<String, (u64, u64)>,
     skipped_by_entry: HashMap<String, u64>,
+    failed_by_entry: HashMap<String, String>,
     transferred_bytes: u64,
     record_count: u64,
     skipped_count: u64,
@@ -122,6 +123,7 @@ impl BucketProgress {
             progress_metric,
             entry_stats: HashMap::new(),
             skipped_by_entry: HashMap::new(),
+            failed_by_entry: HashMap::new(),
             transferred_bytes: 0,
             record_count: 0,
             skipped_count: 0,
@@ -183,6 +185,16 @@ impl BucketProgress {
             .entry(entry_name.to_string())
             .or_insert(0) += 1;
         self.track_displayed_entry(entry_name);
+
+        if !self.quiet {
+            self.progress_bar.set_message(self.message());
+        }
+    }
+
+    pub(super) fn fail_entry(&mut self, entry_name: &str, error: &str) {
+        self.track_displayed_entry(entry_name);
+        self.failed_by_entry
+            .insert(entry_name.to_string(), error.to_string());
 
         if !self.quiet {
             self.progress_bar.set_message(self.message());
@@ -253,14 +265,26 @@ impl BucketProgress {
             };
             let (records, bytes) = self.entry_stats.get(entry).copied().unwrap_or((0, 0));
             let skipped = self.skipped_by_entry.get(entry).copied().unwrap_or(0);
-            lines.push(format!(
-                "  {}{} (🧷 {}, 📦 {}, ⏭️ {})",
-                prefix,
-                entry,
-                records,
-                ByteSize::b(bytes),
-                skipped
-            ));
+            if let Some(err) = self.failed_by_entry.get(entry) {
+                lines.push(format!(
+                    "  {}{} (🧷 {}, 📦 {}, ⏭️ {}, ❌ {})",
+                    prefix,
+                    entry,
+                    records,
+                    ByteSize::b(bytes),
+                    skipped,
+                    err
+                ));
+            } else {
+                lines.push(format!(
+                    "  {}{} (🧷 {}, 📦 {}, ⏭️ {})",
+                    prefix,
+                    entry,
+                    records,
+                    ByteSize::b(bytes),
+                    skipped
+                ));
+            }
         }
         if self.total_entries > self.displayed_entries.len() {
             lines.push(format!(
@@ -403,16 +427,14 @@ where
 
     let mut failed_entries = 0usize;
     let mut completed_entries = 0usize;
-    let mut failure_reasons: Vec<String> = Vec::new();
     while let Some(result) = tasks.join_next().await {
         match result {
             Ok(outcome) => {
                 completed_entries += 1;
                 if let Err(err) = outcome.result {
                     failed_entries += 1;
-                    let reason = format!("{}: {}", outcome.entry_name, err);
-                    failure_reasons.push(reason.clone());
-                    let progress = bucket_progress.lock().await;
+                    let mut progress = bucket_progress.lock().await;
+                    progress.fail_entry(&outcome.entry_name, &err.to_string());
                     if quiet {
                         eprintln!("Failed to copy entry '{}': {}", outcome.entry_name, err);
                     } else {
@@ -426,7 +448,6 @@ where
             Err(err) => {
                 failed_entries += 1;
                 completed_entries += 1;
-                failure_reasons.push(format!("task join error: {}", err));
                 let progress = bucket_progress.lock().await;
                 if quiet {
                     eprintln!("Failed to copy entry: {}", err);
@@ -439,22 +460,14 @@ where
 
     let progress_guard = bucket_progress.lock().await;
     if failed_entries == completed_entries {
-        let mut msg = format!(
+        let msg = format!(
             "Failed to copy any entries from bucket '{}'",
             progress_guard.bucket_name
         );
-        if !failure_reasons.is_empty() {
-            let details = failure_reasons
-                .iter()
-                .take(3)
-                .map(|reason| format!("- {}", reason))
-                .collect::<Vec<_>>()
-                .join("\n");
-            msg = format!("{}\nReasons:\n{}", msg, details);
-        }
 
         if quiet {
             eprintln!("{}", msg);
+            eprintln!("{}", progress_guard.entry_tree());
         } else {
             progress_guard.progress_bar.set_message(format!(
                 "{}\n{}",

--- a/src/cmd/cp/helpers.rs
+++ b/src/cmd/cp/helpers.rs
@@ -84,8 +84,8 @@ pub(super) struct BucketProgress {
     total_entries: usize,
     progress_metric: ProgressMetric,
     entry_stats: HashMap<String, (u64, u64)>,
+    skipped_by_entry: HashMap<String, u64>,
     transferred_bytes: u64,
-    skipped_bytes: u64,
     record_count: u64,
     skipped_count: u64,
     speed: u64,
@@ -113,8 +113,8 @@ impl BucketProgress {
             total_entries,
             progress_metric,
             entry_stats: HashMap::new(),
+            skipped_by_entry: HashMap::new(),
             transferred_bytes: 0,
-            skipped_bytes: 0,
             record_count: 0,
             skipped_count: 0,
             speed: 0,
@@ -171,9 +171,12 @@ impl BucketProgress {
         }
     }
 
-    pub(super) fn skip(&mut self, content_length: u64) {
-        self.skipped_bytes = self.skipped_bytes.saturating_add(content_length);
+    pub(super) fn skip(&mut self, entry_name: &str) {
         self.skipped_count = self.skipped_count.saturating_add(1);
+        *self
+            .skipped_by_entry
+            .entry(entry_name.to_string())
+            .or_insert(0) += 1;
 
         if !self.quiet {
             self.progress_bar.set_message(self.message());
@@ -191,11 +194,10 @@ impl BucketProgress {
         if !self.quiet {
             self.progress_bar.set_position(self.progress_metric.total());
             let msg = format!(
-                "Copied {} records ({}), skipped {} records ({}) from bucket '{}' ({}/s)\n{}",
+                "Copied {} records ({}), skipped {} records from bucket '{}' ({}/s)\n{}",
                 self.record_count,
                 ByteSize::b(self.transferred_bytes),
                 self.skipped_count,
-                ByteSize::b(self.skipped_bytes),
                 self.bucket_name,
                 ByteSize::b(self.speed),
                 self.entry_tree()
@@ -204,11 +206,10 @@ impl BucketProgress {
             self.progress_bar.abandon();
         } else {
             let msg = format!(
-                "Copied {} records ({}), skipped {} records ({}) from bucket '{}'",
+                "Copied {} records ({}), skipped {} records from bucket '{}'",
                 self.record_count,
                 ByteSize::b(self.transferred_bytes),
                 self.skipped_count,
-                ByteSize::b(self.skipped_bytes),
                 self.bucket_name
             );
             println!("{}", msg);
@@ -235,11 +236,10 @@ impl BucketProgress {
 
     fn message(&self) -> String {
         format!(
-            "Copying {} records ({}), skipped {} records ({}) from bucket '{}' ({}/s)\n{}",
+            "Copying {} records ({}), skipped {} records from bucket '{}' ({}/s)\n{}",
             self.record_count,
             ByteSize::b(self.transferred_bytes),
             self.skipped_count,
-            ByteSize::b(self.skipped_bytes),
             self.bucket_name,
             ByteSize::b(self.speed),
             self.entry_tree()
@@ -264,12 +264,14 @@ impl BucketProgress {
                 "├─ "
             };
             let (records, bytes) = self.entry_stats.get(entry).copied().unwrap_or((0, 0));
+            let skipped = self.skipped_by_entry.get(entry).copied().unwrap_or(0);
             lines.push(format!(
-                "  {}{} (🧷 {}, 📦 {})",
+                "  {}{} (🧷 {}, 📦 {}, ⏭️ {})",
                 prefix,
                 entry,
                 records,
-                ByteSize::b(bytes)
+                ByteSize::b(bytes),
+                skipped
             ));
         }
         if self.total_entries > self.displayed_entries.len() {
@@ -761,7 +763,7 @@ async fn flush_batch<V: CopyVisitor + Sync + ?Sized>(
         if let Some(err) = errors.get(&ts) {
             if err.status() == ErrorCode::Conflict {
                 let mut progress = bucket_progress.lock().await;
-                progress.skip(len);
+                progress.skip(entry_name);
             } else if first_error.is_none() {
                 first_error = Some(err.clone());
             }

--- a/src/cmd/cp/helpers.rs
+++ b/src/cmd/cp/helpers.rs
@@ -85,7 +85,9 @@ pub(super) struct BucketProgress {
     progress_metric: ProgressMetric,
     entry_stats: HashMap<String, (u64, u64)>,
     transferred_bytes: u64,
+    skipped_bytes: u64,
     record_count: u64,
+    skipped_count: u64,
     speed: u64,
     history: Vec<(u64, Instant)>,
     speed_update: Instant,
@@ -112,7 +114,9 @@ impl BucketProgress {
             progress_metric,
             entry_stats: HashMap::new(),
             transferred_bytes: 0,
+            skipped_bytes: 0,
             record_count: 0,
+            skipped_count: 0,
             speed: 0,
             history: Vec::new(),
             speed_update: Instant::now(),
@@ -167,6 +171,15 @@ impl BucketProgress {
         }
     }
 
+    pub(super) fn skip(&mut self, content_length: u64) {
+        self.skipped_bytes = self.skipped_bytes.saturating_add(content_length);
+        self.skipped_count = self.skipped_count.saturating_add(1);
+
+        if !self.quiet {
+            self.progress_bar.set_message(self.message());
+        }
+    }
+
     pub(crate) fn print_warning(&self, warning: String) {
         if !self.quiet {
             self.progress_bar
@@ -178,10 +191,12 @@ impl BucketProgress {
         if !self.quiet {
             self.progress_bar.set_position(self.progress_metric.total());
             let msg = format!(
-                "Copied {} records from bucket '{}' ({}, {}/s)\n{}",
+                "Copied {} records ({}), skipped {} records ({}) from bucket '{}' ({}/s)\n{}",
                 self.record_count,
-                self.bucket_name,
                 ByteSize::b(self.transferred_bytes),
+                self.skipped_count,
+                ByteSize::b(self.skipped_bytes),
+                self.bucket_name,
                 ByteSize::b(self.speed),
                 self.entry_tree()
             );
@@ -189,10 +204,12 @@ impl BucketProgress {
             self.progress_bar.abandon();
         } else {
             let msg = format!(
-                "Copied {} records from bucket '{}' ({})",
+                "Copied {} records ({}), skipped {} records ({}) from bucket '{}'",
                 self.record_count,
-                self.bucket_name,
-                ByteSize::b(self.transferred_bytes)
+                ByteSize::b(self.transferred_bytes),
+                self.skipped_count,
+                ByteSize::b(self.skipped_bytes),
+                self.bucket_name
             );
             println!("{}", msg);
         }
@@ -216,31 +233,14 @@ impl BucketProgress {
         }
     }
 
-    pub(crate) fn all_failed_after_partial_copy(&self) {
-        if !self.quiet {
-            let msg = format!(
-                "All entries ended with errors after copying {} records from bucket '{}'\n{}",
-                self.record_count,
-                self.bucket_name,
-                self.entry_tree()
-            );
-            self.progress_bar.set_message(msg);
-            self.progress_bar.abandon();
-        } else {
-            let msg = format!(
-                "All entries ended with errors after copying {} records from bucket '{}'",
-                self.record_count, self.bucket_name
-            );
-            eprintln!("{}", msg);
-        }
-    }
-
     fn message(&self) -> String {
         format!(
-            "Copying {} records from bucket '{}' ({}, {}/s)\n{}",
+            "Copying {} records ({}), skipped {} records ({}) from bucket '{}' ({}/s)\n{}",
             self.record_count,
-            self.bucket_name,
             ByteSize::b(self.transferred_bytes),
+            self.skipped_count,
+            ByteSize::b(self.skipped_bytes),
+            self.bucket_name,
             ByteSize::b(self.speed),
             self.entry_tree()
         )
@@ -432,15 +432,6 @@ where
 
     let progress_guard = bucket_progress.lock().await;
     if failed_entries == completed_entries {
-        if progress_guard.record_count > 0 {
-            progress_guard.all_failed_after_partial_copy();
-            return Err(anyhow::anyhow!(
-                "All entries ended with errors after copying {} records from bucket '{}'",
-                progress_guard.record_count,
-                progress_guard.bucket_name
-            ));
-        }
-
         progress_guard.all_failed();
         return Err(anyhow::anyhow!(
             "Failed to copy any entries from bucket '{}'",
@@ -762,18 +753,31 @@ async fn flush_batch<V: CopyVisitor + Sync + ?Sized>(
         .collect::<Vec<_>>();
     let taken_records = std::mem::take(batch);
     let errors = visitor.copy_records(entry_name, taken_records).await?;
-    if let Some((_, err)) = errors.into_iter().next() {
-        return Err(err);
-    }
+    let mut first_error: Option<ReductError> = None;
 
     for (ts, len) in batch_info {
-        *record_count += 1;
         *timestamp = ts;
+
+        if let Some(err) = errors.get(&ts) {
+            if err.status() == ErrorCode::Conflict {
+                let mut progress = bucket_progress.lock().await;
+                progress.skip(len);
+            } else if first_error.is_none() {
+                first_error = Some(err.clone());
+            }
+            continue;
+        }
+
+        *record_count += 1;
         {
             let mut progress = bucket_progress.lock().await;
             progress.update(entry_name, ts, len);
         }
         sleep(Duration::from_micros(5)).await;
+    }
+
+    if let Some(err) = first_error {
+        return Err(err);
     }
 
     *attempts = DOWNLOAD_ATTEMPTS; // reset attempts on success

--- a/src/cmd/cp/helpers.rs
+++ b/src/cmd/cp/helpers.rs
@@ -216,6 +216,25 @@ impl BucketProgress {
         }
     }
 
+    pub(crate) fn all_failed_after_partial_copy(&self) {
+        if !self.quiet {
+            let msg = format!(
+                "All entries ended with errors after copying {} records from bucket '{}'\n{}",
+                self.record_count,
+                self.bucket_name,
+                self.entry_tree()
+            );
+            self.progress_bar.set_message(msg);
+            self.progress_bar.abandon();
+        } else {
+            let msg = format!(
+                "All entries ended with errors after copying {} records from bucket '{}'",
+                self.record_count, self.bucket_name
+            );
+            eprintln!("{}", msg);
+        }
+    }
+
     fn message(&self) -> String {
         format!(
             "Copying {} records from bucket '{}' ({}, {}/s)\n{}",
@@ -413,6 +432,15 @@ where
 
     let progress_guard = bucket_progress.lock().await;
     if failed_entries == completed_entries {
+        if progress_guard.record_count > 0 {
+            progress_guard.all_failed_after_partial_copy();
+            return Err(anyhow::anyhow!(
+                "All entries ended with errors after copying {} records from bucket '{}'",
+                progress_guard.record_count,
+                progress_guard.bucket_name
+            ));
+        }
+
         progress_guard.all_failed();
         return Err(anyhow::anyhow!(
             "Failed to copy any entries from bucket '{}'",

--- a/src/cmd/cp/helpers.rs
+++ b/src/cmd/cp/helpers.rs
@@ -760,7 +760,13 @@ async fn copy_entry_attachments_once<V: CopyVisitor + Sync + ?Sized>(
 
     let attachments = match src_bucket.read_attachments(entry_name).await {
         Ok(attachments) => attachments,
-        Err(err) if err.status() == ErrorCode::NotFound => HashMap::<String, Value>::new(),
+        Err(err)
+            if err.status() == ErrorCode::NotFound
+                || err.status() == ErrorCode::MethodNotAllowed =>
+        {
+            // Older ReductStore versions may not support attachments endpoints.
+            HashMap::<String, Value>::new()
+        }
         Err(err) => return Err(err),
     };
 

--- a/src/cmd/cp/helpers.rs
+++ b/src/cmd/cp/helpers.rs
@@ -222,24 +222,6 @@ impl BucketProgress {
         }
     }
 
-    pub(crate) fn all_failed(&self) {
-        if !self.quiet {
-            let msg = format!(
-                "Failed to copy any entries from bucket '{}'\n{}",
-                self.bucket_name,
-                self.entry_tree()
-            );
-            self.progress_bar.set_message(msg);
-            self.progress_bar.abandon();
-        } else {
-            let msg = format!(
-                "Failed to copy any entries from bucket '{}'",
-                self.bucket_name
-            );
-            eprintln!("{}", msg);
-        }
-    }
-
     fn message(&self) -> String {
         format!(
             "Copying {} records ({}), skipped {} records from bucket '{}' ({}/s)\n{}",
@@ -453,11 +435,21 @@ where
 
     let progress_guard = bucket_progress.lock().await;
     if failed_entries == completed_entries {
-        progress_guard.all_failed();
-        return Err(anyhow::anyhow!(
+        let msg = format!(
             "Failed to copy any entries from bucket '{}'",
             progress_guard.bucket_name
-        ));
+        );
+        if quiet {
+            eprintln!("{}", msg);
+        } else {
+            progress_guard.progress_bar.set_message(format!(
+                "{}\n{}",
+                msg,
+                progress_guard.entry_tree()
+            ));
+            progress_guard.progress_bar.abandon();
+        }
+        return Err(anyhow::anyhow!(msg));
     }
 
     progress_guard.done();

--- a/src/cmd/cp/helpers.rs
+++ b/src/cmd/cp/helpers.rs
@@ -427,13 +427,26 @@ where
                 completed_entries += 1;
                 if let Err(err) = outcome.result {
                     failed_entries += 1;
-                    eprintln!("Failed to copy entry '{}': {}", outcome.entry_name, err);
+                    let progress = bucket_progress.lock().await;
+                    if quiet {
+                        eprintln!("Failed to copy entry '{}': {}", outcome.entry_name, err);
+                    } else {
+                        progress.print_warning(format!(
+                            "Failed to copy entry '{}': {}",
+                            outcome.entry_name, err
+                        ));
+                    }
                 }
             }
             Err(err) => {
                 failed_entries += 1;
                 completed_entries += 1;
-                eprintln!("Failed to copy entry: {}", err);
+                let progress = bucket_progress.lock().await;
+                if quiet {
+                    eprintln!("Failed to copy entry: {}", err);
+                } else {
+                    progress.print_warning(format!("Failed to copy entry: {}", err));
+                }
             }
         }
     }

--- a/src/cmd/cp/helpers.rs
+++ b/src/cmd/cp/helpers.rs
@@ -1036,6 +1036,45 @@ mod tests {
             bucket_progress.update("entry-1", 1000, 10);
             assert_eq!(bucket_progress.progress_bar.position(), 100);
         }
+
+        #[test]
+        fn test_message_shows_skipped_only_when_non_zero() {
+            let progress = MultiProgress::new();
+            let mut bucket_progress = BucketProgress::new(
+                "test".to_string(),
+                1,
+                1,
+                ProgressMetric::Records { total: 10 },
+                &progress,
+                false,
+            );
+
+            bucket_progress.update("entry-1", 1, 10);
+            let msg = bucket_progress.message();
+            assert!(msg.contains("Copying 1 records (10 B) from bucket 'test'"));
+            assert!(!msg.contains("skipped"));
+
+            bucket_progress.skip("entry-1");
+            let msg = bucket_progress.message();
+            assert!(msg.contains("Copying 1 (skipped 1) records (10 B) from bucket 'test'"));
+        }
+
+        #[test]
+        fn test_entry_tree_shows_failure_for_entries_without_copied_records() {
+            let progress = MultiProgress::new();
+            let mut bucket_progress = BucketProgress::new(
+                "test".to_string(),
+                3,
+                3,
+                ProgressMetric::Records { total: 10 },
+                &progress,
+                false,
+            );
+
+            bucket_progress.fail_entry("imdb", "[MethodNotAllowed] Unknown");
+            let tree = bucket_progress.entry_tree();
+            assert!(tree.contains("imdb (🧷 0, 📦 0 B, ⏭️ 0, ❌ [MethodNotAllowed] Unknown)"));
+        }
     }
 
     mod downloading {

--- a/src/cmd/cp/helpers.rs
+++ b/src/cmd/cp/helpers.rs
@@ -96,6 +96,14 @@ pub(super) struct BucketProgress {
 }
 
 impl BucketProgress {
+    fn track_displayed_entry(&mut self, entry_name: &str) {
+        if self.displayed_entries.len() < self.display_limit
+            && !self.displayed_entries.iter().any(|name| name == entry_name)
+        {
+            self.displayed_entries.push(entry_name.to_string());
+        }
+    }
+
     fn new(
         bucket_name: String,
         display_limit: usize,
@@ -143,11 +151,8 @@ impl BucketProgress {
         let was_empty = entry_stats.0 == 0;
         entry_stats.0 = entry_stats.0.saturating_add(1);
         entry_stats.1 = entry_stats.1.saturating_add(content_length);
-        if was_empty
-            && self.displayed_entries.len() < self.display_limit
-            && !self.displayed_entries.iter().any(|name| name == entry_name)
-        {
-            self.displayed_entries.push(entry_name.to_string());
+        if was_empty {
+            self.track_displayed_entry(entry_name);
         }
 
         let duration = self.history[0].1.elapsed().as_secs();
@@ -177,6 +182,7 @@ impl BucketProgress {
             .skipped_by_entry
             .entry(entry_name.to_string())
             .or_insert(0) += 1;
+        self.track_displayed_entry(entry_name);
 
         if !self.quiet {
             self.progress_bar.set_message(self.message());

--- a/src/cmd/cp/helpers.rs
+++ b/src/cmd/cp/helpers.rs
@@ -403,12 +403,15 @@ where
 
     let mut failed_entries = 0usize;
     let mut completed_entries = 0usize;
+    let mut failure_reasons: Vec<String> = Vec::new();
     while let Some(result) = tasks.join_next().await {
         match result {
             Ok(outcome) => {
                 completed_entries += 1;
                 if let Err(err) = outcome.result {
                     failed_entries += 1;
+                    let reason = format!("{}: {}", outcome.entry_name, err);
+                    failure_reasons.push(reason.clone());
                     let progress = bucket_progress.lock().await;
                     if quiet {
                         eprintln!("Failed to copy entry '{}': {}", outcome.entry_name, err);
@@ -423,6 +426,7 @@ where
             Err(err) => {
                 failed_entries += 1;
                 completed_entries += 1;
+                failure_reasons.push(format!("task join error: {}", err));
                 let progress = bucket_progress.lock().await;
                 if quiet {
                     eprintln!("Failed to copy entry: {}", err);
@@ -435,10 +439,20 @@ where
 
     let progress_guard = bucket_progress.lock().await;
     if failed_entries == completed_entries {
-        let msg = format!(
+        let mut msg = format!(
             "Failed to copy any entries from bucket '{}'",
             progress_guard.bucket_name
         );
+        if !failure_reasons.is_empty() {
+            let details = failure_reasons
+                .iter()
+                .take(3)
+                .map(|reason| format!("- {}", reason))
+                .collect::<Vec<_>>()
+                .join("\n");
+            msg = format!("{}\nReasons:\n{}", msg, details);
+        }
+
         if quiet {
             eprintln!("{}", msg);
         } else {

--- a/src/cmd/cp/helpers.rs
+++ b/src/cmd/cp/helpers.rs
@@ -211,11 +211,15 @@ impl BucketProgress {
     pub(crate) fn done(&self) {
         if !self.quiet {
             self.progress_bar.set_position(self.progress_metric.total());
+            let copied = if self.skipped_count > 0 {
+                format!("{} (skipped {})", self.record_count, self.skipped_count)
+            } else {
+                format!("{}", self.record_count)
+            };
             let msg = format!(
-                "Copied {} records ({}), skipped {} records from bucket '{}' ({}/s)\n{}",
-                self.record_count,
+                "Copied {} records ({}) from bucket '{}' ({}/s)\n{}",
+                copied,
                 ByteSize::b(self.transferred_bytes),
-                self.skipped_count,
                 self.bucket_name,
                 ByteSize::b(self.speed),
                 self.entry_tree()
@@ -223,11 +227,15 @@ impl BucketProgress {
             self.progress_bar.set_message(msg);
             self.progress_bar.abandon();
         } else {
+            let copied = if self.skipped_count > 0 {
+                format!("{} (skipped {})", self.record_count, self.skipped_count)
+            } else {
+                format!("{}", self.record_count)
+            };
             let msg = format!(
-                "Copied {} records ({}), skipped {} records from bucket '{}'",
-                self.record_count,
+                "Copied {} records ({}) from bucket '{}'",
+                copied,
                 ByteSize::b(self.transferred_bytes),
-                self.skipped_count,
                 self.bucket_name
             );
             println!("{}", msg);
@@ -235,11 +243,16 @@ impl BucketProgress {
     }
 
     fn message(&self) -> String {
+        let copied = if self.skipped_count > 0 {
+            format!("{} (skipped {})", self.record_count, self.skipped_count)
+        } else {
+            format!("{}", self.record_count)
+        };
+
         format!(
-            "Copying {} records ({}), skipped {} records from bucket '{}' ({}/s)\n{}",
-            self.record_count,
+            "Copying {} records ({}) from bucket '{}' ({}/s)\n{}",
+            copied,
             ByteSize::b(self.transferred_bytes),
-            self.skipped_count,
             self.bucket_name,
             ByteSize::b(self.speed),
             self.entry_tree()


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

- Fixed misleading final error reporting in `cp` when all entry tasks end in error **after** some records were already copied.
- Previously, the command could print/return `Failed to copy any entries from bucket ...` even when many records were copied before the final per-entry errors.
- Now, if `record_count > 0` and all entries still ended in error, it reports:
  - `All entries ended with errors after copying <N> records from bucket ...`
- Kept the original `Failed to copy any entries ...` message for true zero-copy failures.

### Related issues

Customer report: replication run showed ~90k records copied but ended with `Failed to copy any entries from bucket ...`.

### Does this PR introduce a breaking change?

No.

### Other information:

- Targeted main branch only (no backport in this PR).
- Local targeted test execution depends on local ReductStore availability and failed in this environment due to connection error to `localhost:8383`.