### PR TITLE
snap: use Cargo.toml version for published snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 title: Reduct CLI
 name: reduct-cli
 base: core24
-version: git
+adopt-info: reduct-cli
 summary: Command-line client for ReductStore
 
 description: |
@@ -29,6 +29,10 @@ parts:
   reduct-cli:
     plugin: dump
     source: .snap-build/bin
+    override-pull: |
+      craftctl default
+      VERSION=$(sed -n 's/^version = "\([^"]*\)"$/\1/p' "$CRAFT_PROJECT_DIR/Cargo.toml" | head -n1)
+      craftctl set version="$VERSION"
     organize:
       reduct-cli: bin/reduct-cli
 


### PR DESCRIPTION
## Summary
- replace `version: git` in `snap/snapcraft.yaml` with `adopt-info: reduct-cli`
- set snap version during pull via `craftctl set version` from `Cargo.toml`
- keep snap version aligned with crate semantic version instead of opaque `0+git.<sha>`

## Testing
- verified `snap/snapcraft.yaml` diff
- version extraction command reads `Cargo.toml` package version

## Why
Snap Store currently shows git-hash versions in stable channel for `reduct-cli`. This change makes published version numbers user-facing and semver-based.
