### PR TITLE
snap: prefix published version with git SHA

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,7 +32,9 @@ parts:
     override-pull: |
       craftctl default
       VERSION=$(sed -n 's/^version = "\([^"]*\)"$/\1/p' "$CRAFT_PROJECT_DIR/Cargo.toml" | head -n1)
-      craftctl set version="$VERSION"
+      SHA=${GITHUB_SHA:-$(git -C "$CRAFT_PROJECT_DIR" rev-parse --short=7 HEAD 2>/dev/null || echo local)}
+      SHA=${SHA:0:7}
+      craftctl set version="git.${SHA}-${VERSION}"
     organize:
       reduct-cli: bin/reduct-cli
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,7 +34,7 @@ parts:
       VERSION=$(sed -n 's/^version = "\([^"]*\)"$/\1/p' "$CRAFT_PROJECT_DIR/Cargo.toml" | head -n1)
       SHA=${GITHUB_SHA:-$(git -C "$CRAFT_PROJECT_DIR" rev-parse --short=7 HEAD 2>/dev/null || echo local)}
       SHA=${SHA:0:7}
-      craftctl set version="git.${SHA}-${VERSION}"
+      craftctl set version="${VERSION}-git.${SHA}"
     organize:
       reduct-cli: bin/reduct-cli
 


### PR DESCRIPTION
## Summary
- keep Cargo version extraction for snap builds
- prefix published snap version with git short SHA
- set final format to `git.<sha>-<crate_version>`

## Why
After switching away from `version: git`, we lost the git-hash visibility in Snap Store versions. This restores a git-prefixed version style while still including the crate semver.

## Example
- `git.19ca5c9-0.11.1`
