### PR TITLE
snap: require git hash in published version

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,9 +32,13 @@ parts:
     override-pull: |
       craftctl default
       VERSION=$(sed -n 's/^version = "\([^"]*\)"$/\1/p' "$CRAFT_PROJECT_DIR/Cargo.toml" | head -n1)
-      SHA=${GITHUB_SHA:-$(git -C "$CRAFT_PROJECT_DIR" rev-parse --short=7 HEAD 2>/dev/null || echo local)}
+      SHA=${GITHUB_SHA:-$(git -C "$CRAFT_PROJECT_DIR" rev-parse --short=7 HEAD 2>/dev/null || true)}
       SHA=${SHA:0:7}
-      craftctl set version="${VERSION}-git.${SHA}"
+      if [ -z "$SHA" ]; then
+        echo "ERROR: Unable to determine git commit SHA for snap version" >&2
+        exit 1
+      fi
+      craftctl set version="${VERSION}-git${SHA}"
     organize:
       reduct-cli: bin/reduct-cli
 


### PR DESCRIPTION
## Summary
- format snap version as `VERSION-gitSHA` (for example `0.11.1-git86f2734`)
- remove `.local` fallback
- fail snap build when commit SHA is unavailable

## Validation
- built locally: `cargo build --release`
- verified computed snap version locally: `0.11.1-git96c71b9`
