### PR TITLE
snap: require GITHUB_SHA for version suffix

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,10 +32,9 @@ parts:
     override-pull: |
       craftctl default
       VERSION=$(sed -n 's/^version = "\([^"]*\)"$/\1/p' "$CRAFT_PROJECT_DIR/Cargo.toml" | head -n1)
-      SHA=${GITHUB_SHA:-$(git -C "$CRAFT_PROJECT_DIR" rev-parse --short=7 HEAD 2>/dev/null || true)}
-      SHA=${SHA:0:7}
+      SHA=${GITHUB_SHA:0:7}
       if [ -z "$SHA" ]; then
-        echo "ERROR: Unable to determine git commit SHA for snap version" >&2
+        echo "ERROR: GITHUB_SHA is required for snap version" >&2
         exit 1
       fi
       craftctl set version="${VERSION}-git${SHA}"


### PR DESCRIPTION
## Summary
- use only  for snap version suffix
- fail fast if  is missing
- keep snap version format as 

## Why
PR #213 was closed; this reopens the fix in a fresh PR branch.
