### PR TITLE
snap: copy reduct-bridge versioning approach

### DIFF
--- a/.github/actions/snap-release/action.yml
+++ b/.github/actions/snap-release/action.yml
@@ -39,6 +39,35 @@ runs:
         set -euo pipefail
         chmod +x .snap-build/bin/reduct-cli
 
+    - name: Set snap version from Cargo.toml and GITHUB_SHA
+      shell: bash
+      run: |
+        set -euo pipefail
+        python3 - <<'PY'
+        import os, re
+        from pathlib import Path
+
+        cargo = Path('Cargo.toml').read_text(encoding='utf-8')
+        m = re.search(r'(?ms)^\[package\]\n(.*?)(?:^\[|\Z)', cargo)
+        if not m:
+            raise SystemExit('Could not find [package] section in Cargo.toml')
+        v = re.search(r'^version\s*=\s*"([^"]+)"\s*$', m.group(1), re.M)
+        if not v:
+            raise SystemExit('Could not find package.version in Cargo.toml')
+        sha = os.environ.get('GITHUB_SHA', '')[:7]
+        if not sha:
+            raise SystemExit('GITHUB_SHA is required for snap version')
+        version = f"{v.group(1)}-git{sha}"
+
+        p = Path('snap/snapcraft.yaml')
+        text = p.read_text(encoding='utf-8')
+        text, n = re.subn(r'^version:\s*"[^"]*"\s*$', f'version: "{version}"', text, count=1, flags=re.M)
+        if n != 1:
+            raise SystemExit('Could not update version in snap/snapcraft.yaml')
+        p.write_text(text, encoding='utf-8')
+        print(f'set snap version to {version}')
+        PY
+
     - uses: snapcore/action-build@v1
       id: build-snap
       with:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 title: Reduct CLI
 name: reduct-cli
 base: core24
-adopt-info: reduct-cli
+version: "0"
 summary: Command-line client for ReductStore
 
 description: |
@@ -29,15 +29,6 @@ parts:
   reduct-cli:
     plugin: dump
     source: .snap-build/bin
-    override-pull: |
-      craftctl default
-      VERSION=$(sed -n 's/^version = "\([^"]*\)"$/\1/p' "$CRAFT_PROJECT_DIR/Cargo.toml" | head -n1)
-      SHA=${GITHUB_SHA:0:7}
-      if [ -z "$SHA" ]; then
-        echo "ERROR: GITHUB_SHA is required for snap version" >&2
-        exit 1
-      fi
-      craftctl set version="${VERSION}-git${SHA}"
     organize:
       reduct-cli: bin/reduct-cli
 


### PR DESCRIPTION
## Summary
- move snap version resolution out of snapcraft override hooks into GitHub Action
- derive  from Cargo.toml and append 
- write the resolved version directly into  before build
- keep strict requirement: fail if  is missing

## Why
The snapcraft build instance does not always expose git metadata, so resolving SHA inside snapcraft can fail even in CI. This mirrors the working reduct-bridge approach.
