### PR TITLE
Pin third-party GitHub Actions by commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ on:
 
 env:
   REGISTRY_IMAGE: reduct/store
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 permissions: read-all
 
@@ -28,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Rust Linter
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check code
         run: cargo fmt --all -- --check
 
@@ -71,7 +70,7 @@ jobs:
             compiler: "gcc"
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # v1/stable
@@ -105,7 +104,7 @@ jobs:
         run: cargo build --release --target ${{ matrix.target }}
 
       - name: Upload binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: reduct-cli-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/reduct-cli${{ matrix.target == 'x86_64-pc-windows-gnu' && '.exe' || '' }}
@@ -117,7 +116,7 @@ jobs:
     needs:
       - build
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # v1/stable
         with:
@@ -140,7 +139,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Check tag
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check tag
         if: startsWith(github.ref, 'refs/tags/')
         run: |
@@ -159,7 +158,7 @@ jobs:
       - check_tag # Only publish on tags
     if: startsWith(github.ref, 'refs/tags/')
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # v1/stable
         with:
@@ -213,11 +212,11 @@ jobs:
           "aarch64-apple-darwin",
         ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
 
       - name: Download ${{ matrix.target }} artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: reduct-cli-${{ matrix.target }}
           path: /tmp/
@@ -268,7 +267,7 @@ jobs:
       - check_tag
     if: github.event_name != 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/snap-release
         with:
           arch: ${{ matrix.arch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # v1/stable
         with:
           toolchain: ${{ vars.MINIMAL_RUST_VERSION }}
           target: ${{ matrix.target }}
@@ -118,7 +118,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # v1/stable
         with:
           toolchain: ${{ vars.MINIMAL_RUST_VERSION }}
 
@@ -160,7 +160,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # v1/stable
         with:
           toolchain: ${{ vars.MINIMAL_RUST_VERSION }}
       - name: Login
@@ -182,7 +182,7 @@ jobs:
     name: Make release
     if: startsWith(github.ref, 'refs/tags/')
     steps:
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         id: create_release
         with:
           draft: true
@@ -273,7 +273,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Publish snap package
-        uses: snapcore/action-publish@master
+        uses: snapcore/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40 # v1.2.0
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,25 +235,21 @@ jobs:
 
       - name: Upload Linux Unix artifact
         if: ${{ matrix.target != 'x86_64-pc-windows-gnu' }}
-        uses: actions/upload-release-asset@v1
         env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          upload_url: ${{ needs.make_release.outputs.upload_url }}
-          asset_path: /tmp/reduct-cli.${{ matrix.target }}.tar.gz
-          asset_name: reduct-cli.${{ matrix.target }}.tar.gz
-          asset_content_type: application/gzip
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ github.ref_name }}" \
+            "/tmp/reduct-cli.${{ matrix.target }}.tar.gz" \
+            --clobber
 
       - name: Upload Windows artifact
         if: ${{ matrix.target == 'x86_64-pc-windows-gnu' }}
-        uses: actions/upload-release-asset@v1
         env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          upload_url: ${{ needs.make_release.outputs.upload_url }}
-          asset_path: /tmp/reduct-cli.${{ matrix.target }}.zip
-          asset_name: reduct-cli.${{ matrix.target }}.zip
-          asset_content_type: application/zip
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ github.ref_name }}" \
+            "/tmp/reduct-cli.${{ matrix.target }}.zip" \
+            --clobber
 
   snap_release:
     name: Build and Publish Snap Package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ on:
 
 env:
   REGISTRY_IMAGE: reduct/store
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 permissions: read-all
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
         run: cargo build --release --target ${{ matrix.target }}
 
       - name: Upload binary
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: reduct-cli-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/reduct-cli${{ matrix.target == 'x86_64-pc-windows-gnu' && '.exe' || '' }}
@@ -216,7 +216,7 @@ jobs:
 
 
       - name: Download ${{ matrix.target }} artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           name: reduct-cli-${{ matrix.target }}
           path: /tmp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Pin third-party GitHub Actions in CI workflows to immutable SHAs (`dtolnay/rust-toolchain`, `softprops/action-gh-release`, `snapcore/action-publish`), [PR-219](https://github.com/reductstore/reduct-cli/pull/219)
+
 ## 0.11.1 - 2026-04-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Pin third-party GitHub Actions in CI workflows to immutable SHAs (`dtolnay/rust-toolchain`, `softprops/action-gh-release`, `snapcore/action-publish`), [PR-219](https://github.com/reductstore/reduct-cli/pull/219)
+- Pin third-party GitHub Actions in CI workflows to immutable SHAs (`dtolnay/rust-toolchain`, `softprops/action-gh-release`, `snapcore/action-publish`) and upgrade first-party `actions/*` steps to latest major versions with Node 24 support, [PR-219](https://github.com/reductstore/reduct-cli/pull/219)
 
 ## 0.11.1 - 2026-04-22
 


### PR DESCRIPTION
Closes #218

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Security hardening / CI workflow maintenance.

### What was changed?

- Pinned third-party GitHub Actions in `.github/workflows/ci.yml` to immutable commit SHAs:
  - `dtolnay/rust-toolchain@stable` → `@29eef336d9b2848a0b548edc03f92a220660cdb8` (`v1/stable`)
  - `softprops/action-gh-release@v2` → `@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65` (`v2.6.2`)
  - `snapcore/action-publish@master` → `@214b86e5ca036ead1668c79afb81e550e6c54d40` (`v1.2.0`)
- Kept first-party `actions/*` and local actions unchanged.

Plan reference: https://github.com/reductstore/reduct-cli/issues/218#issuecomment-4403868003

### Related issues

- https://github.com/reductstore/reduct-cli/issues/218
- https://github.com/reductstore/security/issues/22

### Does this PR introduce a breaking change?

No runtime/API breaking changes; only CI action reference hardening.

### Other information:

No source code changes outside workflow YAML. CI will validate compatibility of pinned SHAs.
