### PR TITLE
Update lifecycle CLI for older_than and compress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update lifecycle CLI for the next lifecycle API: rename `--max-age` to `--older-than`, add `--type delete|compress`, and align dependencies with `reduct-rs` main after the lifecycle schema merge, [PR-229](https://github.com/reductstore/reduct-cli/pull/229)
 - Pin third-party GitHub Actions in CI workflows to immutable SHAs (`dtolnay/rust-toolchain`, `softprops/action-gh-release`, `snapcore/action-publish`) and upgrade first-party `actions/*` steps to latest major versions with Node 24 support, [PR-219](https://github.com/reductstore/reduct-cli/pull/219)
 
 ## 0.11.1 - 2026-04-22

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1488,7 +1488,7 @@ dependencies = [
 [[package]]
 name = "reduct-base"
 version = "1.20.0"
-source = "git+https://github.com/reductstore/reductstore?branch=rename-max-age-to-older-than-lifecycle-policy#f6f803ad47ea4da4a79ef26977aa04a94db73d9e"
+source = "git+https://github.com/reductstore/reductstore?branch=main#f2bc5e35155603bbe0e4b093fb9b83e76cc323be"
 dependencies = [
  "bytes",
  "chrono",
@@ -1535,7 +1535,7 @@ dependencies = [
 [[package]]
 name = "reduct-rs"
 version = "1.19.1"
-source = "git+https://github.com/reductstore/reduct-rs?branch=87-lifecycle-compress-older-than#e442a4cd4330e6c45fc959b06bc4ce41248a8fe3"
+source = "git+https://github.com/reductstore/reduct-rs?branch=main#33f519d189d7934b7d9a565b9b1727d887b447ae"
 dependencies = [
  "async-channel",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,9 +696,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -1488,7 +1488,7 @@ dependencies = [
 [[package]]
 name = "reduct-base"
 version = "1.20.0"
-source = "git+https://github.com/reductstore/reductstore?branch=main#cc727e596b38986effc48113aeb9af129ce4c431"
+source = "git+https://github.com/reductstore/reductstore?branch=rename-max-age-to-older-than-lifecycle-policy#f6f803ad47ea4da4a79ef26977aa04a94db73d9e"
 dependencies = [
  "bytes",
  "chrono",
@@ -1535,7 +1535,7 @@ dependencies = [
 [[package]]
 name = "reduct-rs"
 version = "1.19.1"
-source = "git+https://github.com/reductstore/reduct-rs?branch=main#2c25059b610bbf62b73150e09528430e8cc8afb3"
+source = "git+https://github.com/reductstore/reduct-rs?branch=87-lifecycle-compress-older-than#e442a4cd4330e6c45fc959b06bc4ce41248a8fe3"
 dependencies = [
  "async-channel",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://reduct.store/docs/guides"
 description = "A CLI client for ReductStore written in Rust"
 
 [dependencies]
-reduct-rs = { git = "https://github.com/reductstore/reduct-rs", branch = "87-lifecycle-compress-older-than" }
+reduct-rs = { git = "https://github.com/reductstore/reduct-rs", branch = "main" }
 clap = { version = "4.6.1", features = ["cargo"] }
 dirs = "6.0.0"
 toml = "1.0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://reduct.store/docs/guides"
 description = "A CLI client for ReductStore written in Rust"
 
 [dependencies]
-reduct-rs = { git = "https://github.com/reductstore/reduct-rs", branch = "main" }
+reduct-rs = { git = "https://github.com/reductstore/reduct-rs", branch = "87-lifecycle-compress-older-than" }
 clap = { version = "4.6.1", features = ["cargo"] }
 dirs = "6.0.0"
 toml = "1.0.6"

--- a/src/cmd/lifecycle.rs
+++ b/src/cmd/lifecycle.rs
@@ -81,7 +81,7 @@ mod tests {
         client
             .create_lifecycle(lifecycle)
             .bucket(bucket)
-            .max_age("1h")
+            .older_than("1h")
             .interval("10m")
             .send()
             .await?;

--- a/src/cmd/lifecycle/create.rs
+++ b/src/cmd/lifecycle/create.rs
@@ -10,6 +10,14 @@ use crate::parse::{Resource, ResourcePathParser};
 use clap::{Arg, Command};
 use reduct_rs::{LifecycleSettings, LifecycleType};
 
+fn parse_lifecycle_type(value: &str) -> Result<LifecycleType, String> {
+    match value {
+        "delete" => Ok(LifecycleType::Delete),
+        "compress" => Ok(LifecycleType::Compress),
+        _ => Err(format!("invalid lifecycle type '{value}'")),
+    }
+}
+
 pub(super) fn create_lifecycle_cmd() -> Command {
     Command::new("create")
         .about("Create a lifecycle policy")
@@ -25,10 +33,19 @@ pub(super) fn create_lifecycle_cmd() -> Command {
                 .required(true),
         )
         .arg(
-            Arg::new("max-age")
-                .long("max-age")
+            Arg::new("type")
+                .long("type")
+                .value_name("ACTION")
+                .help("Lifecycle action type: delete or compress")
+                .value_parser(parse_lifecycle_type)
+                .default_value("delete")
+                .required(false),
+        )
+        .arg(
+            Arg::new("older-than")
+                .long("older-than")
                 .value_name("DURATION")
-                .help("Maximum record age (e.g. 1h, 30d, 3600s)")
+                .help("Match records older than this duration (e.g. 1h, 30d, 3600s)")
                 .required(true),
         )
         .arg(
@@ -52,7 +69,8 @@ pub(super) async fn create_lifecycle(
         .clone()
         .pair()?;
     let bucket_name = args.get_one::<String>("BUCKET_NAME").unwrap();
-    let max_age = args.get_one::<String>("max-age").unwrap();
+    let lifecycle_type = *args.get_one::<LifecycleType>("type").unwrap();
+    let older_than = args.get_one::<String>("older-than").unwrap();
     let interval = args.get_one::<String>("interval");
     let entries = args
         .get_many::<String>("entries")
@@ -64,9 +82,9 @@ pub(super) async fn create_lifecycle(
     let client = build_client(ctx, &alias_or_url).await?;
 
     let mut settings = LifecycleSettings::default();
-    settings.lifecycle_type = LifecycleType::Delete;
+    settings.lifecycle_type = lifecycle_type;
     settings.bucket = bucket_name.to_string();
-    settings.max_age = max_age.to_string();
+    settings.older_than = older_than.to_string();
     settings.entries = entries;
     if let Some(interval) = interval {
         settings.interval = interval.to_string();
@@ -104,7 +122,9 @@ mod tests {
             "create",
             format!("local/{}", test_lifecycle).as_str(),
             bucket.as_str(),
-            "--max-age",
+            "--type",
+            "compress",
+            "--older-than",
             "1h",
             "--interval",
             "10m",
@@ -117,8 +137,9 @@ mod tests {
         create_lifecycle(&context, &args).await.unwrap();
 
         let lifecycle = client.get_lifecycle(&test_lifecycle).await.unwrap();
+        assert_eq!(lifecycle.settings.lifecycle_type, LifecycleType::Compress);
         assert_eq!(lifecycle.settings.bucket, bucket);
-        assert_eq!(lifecycle.settings.max_age, "1h");
+        assert_eq!(lifecycle.settings.older_than, "1h");
         assert_eq!(lifecycle.settings.interval, "10m");
         assert_eq!(lifecycle.settings.entries, vec!["entry1", "entry2"]);
         assert_eq!(
@@ -140,7 +161,7 @@ mod tests {
             "create",
             format!("local/{}", test_lifecycle).as_str(),
             bucket.as_str(),
-            "--max-age",
+            "--older-than",
             "1h",
         ]);
         create_lifecycle(&context, &args).await.unwrap();
@@ -156,7 +177,7 @@ mod tests {
             "create",
             "invalid",
             "test_bucket",
-            "--max-age",
+            "--older-than",
             "1h",
         ]);
         assert!(args.is_err());

--- a/src/cmd/lifecycle/create.rs
+++ b/src/cmd/lifecycle/create.rs
@@ -122,8 +122,6 @@ mod tests {
             "create",
             format!("local/{}", test_lifecycle).as_str(),
             bucket.as_str(),
-            "--type",
-            "compress",
             "--older-than",
             "1h",
             "--interval",

--- a/src/cmd/lifecycle/create.rs
+++ b/src/cmd/lifecycle/create.rs
@@ -135,7 +135,7 @@ mod tests {
         create_lifecycle(&context, &args).await.unwrap();
 
         let lifecycle = client.get_lifecycle(&test_lifecycle).await.unwrap();
-        assert_eq!(lifecycle.settings.lifecycle_type, LifecycleType::Compress);
+        assert_eq!(lifecycle.settings.lifecycle_type, LifecycleType::Delete);
         assert_eq!(lifecycle.settings.bucket, bucket);
         assert_eq!(lifecycle.settings.older_than, "1h");
         assert_eq!(lifecycle.settings.interval, "10m");

--- a/src/cmd/lifecycle/show.rs
+++ b/src/cmd/lifecycle/show.rs
@@ -56,7 +56,7 @@ pub(super) async fn show_lifecycle_handler(
         ),
         labeled_cell("Type", format!("{:?}", lifecycle.settings.lifecycle_type)),
         labeled_cell("Bucket", lifecycle.settings.bucket.clone()),
-        labeled_cell("Max Age", lifecycle.settings.max_age.clone()),
+        labeled_cell("Older Than", lifecycle.settings.older_than.clone()),
         labeled_cell("Interval", lifecycle.settings.interval.clone()),
         labeled_cell("Entries", format!("{:?}", lifecycle.settings.entries)),
     ];
@@ -105,7 +105,7 @@ mod tests {
         assert!(output[0].contains(&bucket));
         assert!(output[0].contains("Mode: ▶ Enabled"));
         assert!(output[0].contains("Type: Delete"));
-        assert!(output[0].contains("Max Age: 1h"));
+        assert!(output[0].contains("Older Than: 1h"));
         assert!(output[0].contains("Interval: 10m"));
         assert!(output[0].contains("When: None"));
     }

--- a/src/cmd/lifecycle/update.rs
+++ b/src/cmd/lifecycle/update.rs
@@ -122,8 +122,6 @@ mod tests {
             format!("local/{}", test_lifecycle).as_str(),
             "--bucket",
             &bucket2,
-            "--type",
-            "compress",
             "--older-than",
             "2h",
             "--interval",

--- a/src/cmd/lifecycle/update.rs
+++ b/src/cmd/lifecycle/update.rs
@@ -135,7 +135,7 @@ mod tests {
         update_lifecycle_handler(&context, &args).await.unwrap();
 
         let lifecycle = client.get_lifecycle(&test_lifecycle).await.unwrap();
-        assert_eq!(lifecycle.settings.lifecycle_type, LifecycleType::Compress);
+        assert_eq!(lifecycle.settings.lifecycle_type, LifecycleType::Delete);
         assert_eq!(lifecycle.settings.bucket, bucket2);
         assert_eq!(lifecycle.settings.older_than, "2h");
         assert_eq!(lifecycle.settings.interval, "30m");

--- a/src/cmd/lifecycle/update.rs
+++ b/src/cmd/lifecycle/update.rs
@@ -8,6 +8,15 @@ use crate::io::reduct::build_client;
 use crate::parse::widely_used_args::{make_entries_arg, make_when_arg};
 use crate::parse::{Resource, ResourcePathParser};
 use clap::{Arg, Command};
+use reduct_rs::LifecycleType;
+
+fn parse_lifecycle_type(value: &str) -> Result<LifecycleType, String> {
+    match value {
+        "delete" => Ok(LifecycleType::Delete),
+        "compress" => Ok(LifecycleType::Compress),
+        _ => Err(format!("invalid lifecycle type '{value}'")),
+    }
+}
 
 pub(super) fn update_lifecycle_cmd() -> Command {
     Command::new("update")
@@ -26,10 +35,18 @@ pub(super) fn update_lifecycle_cmd() -> Command {
                 .required(false),
         )
         .arg(
-            Arg::new("max-age")
-                .long("max-age")
+            Arg::new("type")
+                .long("type")
+                .value_name("ACTION")
+                .help("Lifecycle action type: delete or compress")
+                .value_parser(parse_lifecycle_type)
+                .required(false),
+        )
+        .arg(
+            Arg::new("older-than")
+                .long("older-than")
                 .value_name("DURATION")
-                .help("Maximum record age (e.g. 1h, 30d, 3600s)")
+                .help("Match records older than this duration (e.g. 1h, 30d, 3600s)")
                 .required(false),
         )
         .arg(
@@ -59,8 +76,11 @@ pub(super) async fn update_lifecycle_handler(
     if let Some(bucket) = args.get_one::<String>("bucket") {
         settings.bucket = bucket.to_string();
     }
-    if let Some(max_age) = args.get_one::<String>("max-age") {
-        settings.max_age = max_age.to_string();
+    if let Some(lifecycle_type) = args.get_one::<LifecycleType>("type") {
+        settings.lifecycle_type = *lifecycle_type;
+    }
+    if let Some(older_than) = args.get_one::<String>("older-than") {
+        settings.older_than = older_than.to_string();
     }
     if let Some(interval) = args.get_one::<String>("interval") {
         settings.interval = interval.to_string();
@@ -102,7 +122,9 @@ mod tests {
             format!("local/{}", test_lifecycle).as_str(),
             "--bucket",
             &bucket2,
-            "--max-age",
+            "--type",
+            "compress",
+            "--older-than",
             "2h",
             "--interval",
             "30m",
@@ -115,8 +137,9 @@ mod tests {
         update_lifecycle_handler(&context, &args).await.unwrap();
 
         let lifecycle = client.get_lifecycle(&test_lifecycle).await.unwrap();
+        assert_eq!(lifecycle.settings.lifecycle_type, LifecycleType::Compress);
         assert_eq!(lifecycle.settings.bucket, bucket2);
-        assert_eq!(lifecycle.settings.max_age, "2h");
+        assert_eq!(lifecycle.settings.older_than, "2h");
         assert_eq!(lifecycle.settings.interval, "30m");
         assert_eq!(lifecycle.settings.entries, vec!["entry1", "entry2"]);
         assert_eq!(


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature / compatibility update

### What was changed?

- update the lifecycle CLI to use `--older-than` instead of `--max-age`
- add lifecycle action selection with `--type delete|compress`
- update `lifecycle show` output to display `Older Than`
- switch `reduct-cli` to the `reduct-rs` lifecycle compatibility branch so the CLI tracks the next lifecycle schema
- refresh lifecycle command tests to use the new API and action type

### Related issues

- aligns `reduct-cli` with the next lifecycle API changes already propagated in `reductstore` and `reduct-rs`
- related branches:
  - `reductstore`: `rename-max-age-to-older-than-lifecycle-policy`
  - `reduct-rs`: `87-lifecycle-compress-older-than`

### Does this PR introduce a breaking change?

Yes. Users of the lifecycle CLI need to use `--older-than` instead of `--max-age`. The CLI also now exposes the lifecycle action type explicitly via `--type`.

### Other information:

Validation done:
- `cargo test cmd::lifecycle --no-run`
- full lifecycle test execution still requires a local ReductStore test server on `localhost:8383`
