### PR TITLE
Show lifecycle type in full lifecycle list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Show lifecycle `type` in `reduct-cli lifecycle ls --full` and refresh the `reduct-rs` dependency to the latest `main`, [PR-230](https://github.com/reductstore/reduct-cli/pull/230)
 - Update lifecycle CLI for the next lifecycle API: rename `--max-age` to `--older-than`, add `--type delete|compress`, and align dependencies with `reduct-rs` main after the lifecycle schema merge, [PR-229](https://github.com/reductstore/reduct-cli/pull/229)
 - Pin third-party GitHub Actions in CI workflows to immutable SHAs (`dtolnay/rust-toolchain`, `softprops/action-gh-release`, `snapcore/action-publish`) and upgrade first-party `actions/*` steps to latest major versions with Node 24 support, [PR-219](https://github.com/reductstore/reduct-cli/pull/219)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1488,7 +1488,7 @@ dependencies = [
 [[package]]
 name = "reduct-base"
 version = "1.20.0"
-source = "git+https://github.com/reductstore/reductstore?branch=main#f2bc5e35155603bbe0e4b093fb9b83e76cc323be"
+source = "git+https://github.com/reductstore/reductstore?branch=main#58d26a078a88f61a990dcaec2669e078d64f46f5"
 dependencies = [
  "bytes",
  "chrono",
@@ -1535,7 +1535,7 @@ dependencies = [
 [[package]]
 name = "reduct-rs"
 version = "1.19.1"
-source = "git+https://github.com/reductstore/reduct-rs?branch=main#33f519d189d7934b7d9a565b9b1727d887b447ae"
+source = "git+https://github.com/reductstore/reduct-rs?branch=main#6b1710dcd12a664adb5e48ef1c3aa4d16b7e925c"
 dependencies = [
  "async-channel",
  "async-stream",

--- a/src/cmd/lifecycle/ls.rs
+++ b/src/cmd/lifecycle/ls.rs
@@ -8,7 +8,7 @@ use crate::cmd::ALIAS_OR_URL_HELP;
 use crate::io::std::output;
 use clap::ArgAction::SetTrue;
 use clap::{Arg, Command};
-use reduct_rs::LifecycleInfo;
+use reduct_rs::{LifecycleInfo, LifecycleType};
 use tabled::settings::Style;
 use tabled::{Table, Tabled};
 
@@ -36,6 +36,8 @@ struct LifecycleTable {
     name: String,
     #[tabled(rename = "Status")]
     status: String,
+    #[tabled(rename = "Type")]
+    lifecycle_type: String,
     #[tabled(rename = "Mode")]
     mode: String,
     #[tabled(rename = "Provisioned")]
@@ -51,6 +53,7 @@ impl From<LifecycleInfo> for LifecycleTable {
             } else {
                 "⏸ Idle".to_string()
             },
+            lifecycle_type: format_lifecycle_type(lifecycle.lifecycle_type),
             mode: format_mode_with_icon(lifecycle.mode),
             provisioned: if lifecycle.is_provisioned {
                 "✓".to_string()
@@ -58,6 +61,13 @@ impl From<LifecycleInfo> for LifecycleTable {
                 "-".to_string()
             },
         }
+    }
+}
+
+fn format_lifecycle_type(lifecycle_type: LifecycleType) -> String {
+    match lifecycle_type {
+        LifecycleType::Delete => "Delete".to_string(),
+        LifecycleType::Compress => "Compress".to_string(),
     }
 }
 
@@ -96,7 +106,26 @@ mod tests {
     use crate::cmd::lifecycle::tests::{prepare_lifecycle, unique_name};
     use crate::context::tests::context;
     use crate::context::CliContext;
+    use chrono::Utc;
+    use reduct_rs::LifecycleMode;
     use rstest::rstest;
+
+    #[test]
+    fn test_lifecycle_table_includes_type() {
+        let lifecycle = LifecycleInfo {
+            name: "test-lifecycle".to_string(),
+            is_provisioned: true,
+            is_running: false,
+            lifecycle_type: LifecycleType::Compress,
+            mode: LifecycleMode::Enabled,
+            last_run: Some(Utc::now()),
+        };
+
+        let row = LifecycleTable::from(lifecycle);
+        assert_eq!(row.lifecycle_type, "Compress");
+        assert_eq!(row.mode, "▶ Enabled");
+        assert_eq!(row.provisioned, "✓");
+    }
 
     #[rstest]
     #[tokio::test]
@@ -134,6 +163,7 @@ mod tests {
         let output = context.stdout().history();
         assert_eq!(output.len(), 1);
         assert!(output[0].contains(&lifecycle));
+        assert!(output[0].contains("Delete"));
         assert!(output[0].contains("▶ Enabled"));
     }
 }


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

- updated the reduct-cli lockfile to use the latest `reduct-rs` from `main`
- added a `Type` column to `reduct-cli lifecycle ls --full`
- display lifecycle type as `Delete` / `Compress` in the full lifecycle table
- added a focused unit test for the new full-table type rendering

### Related issues

None linked.

### Does this PR introduce a breaking change?

No.

### Other information:

The existing lifecycle list integration-style tests in this repo require a local ReductStore server on `localhost:8383`, which is not running in this environment. The new table output path was validated with a focused unit test and full test compilation.
