### PR TITLE
Fix entry status rendering in bucket show --full

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Show actual entry deletion status in `bucket show --full` instead of inferring `Empty`/`Ready` from record counts, [PR-236](https://github.com/reductstore/reduct-cli/pull/236)
+
 ## 0.12.0 - 2026-06-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.12.1 - 2026-06-18
+
 ### Fixed
 
 - Show actual entry deletion status in `bucket show --full` instead of inferring `Empty`/`Ready` from record counts, [PR-236](https://github.com/reductstore/reduct-cli/pull/236)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1489,7 +1489,7 @@ dependencies = [
 
 [[package]]
 name = "reduct-cli"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reduct-cli"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 authors = ["Alexey Timin <atimin@reduct.store>"]
 rust-version = "1.89.0"

--- a/src/cmd/bucket/show.rs
+++ b/src/cmd/bucket/show.rs
@@ -57,19 +57,15 @@ struct EntryTable {
 
 impl From<EntryInfo> for EntryTable {
     fn from(entry: EntryInfo) -> Self {
-        let status = if entry.record_count == 0 {
-            "⚪ Empty".to_string()
-        } else {
-            "✅ Ready".to_string()
-        };
+        let is_empty = entry.record_count == 0;
         Self {
             name: entry.name,
             record_count: entry.record_count,
             block_count: entry.block_count,
-            status,
+            status: print_bucket_status(&entry.status),
             size: ByteSize(entry.size).display().si().to_string(),
-            oldest_record: timestamp_to_iso(entry.oldest_record, entry.record_count == 0),
-            latest_record: timestamp_to_iso(entry.latest_record, entry.record_count == 0),
+            oldest_record: timestamp_to_iso(entry.oldest_record, is_empty),
+            latest_record: timestamp_to_iso(entry.latest_record, is_empty),
         }
     }
 }
@@ -187,6 +183,7 @@ fn print_full_bucket(ctx: &CliContext, bucket: FullBucketInfo) -> anyhow::Result
 mod tests {
     use super::*;
     use crate::context::tests::{bucket, context};
+    use reduct_rs::ResourceStatus;
     use rstest::rstest;
 
     #[rstest]
@@ -283,5 +280,41 @@ mod tests {
                 .to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn test_entry_table_uses_entry_status_for_deleting_entries() {
+        let entry = EntryInfo {
+            name: "left_camera/camera_info".to_string(),
+            size: 473_577,
+            record_count: 1000,
+            block_count: 1,
+            oldest_record: 1,
+            latest_record: 1000,
+            status: ResourceStatus::Deleting,
+        };
+
+        let row = EntryTable::from(entry);
+        assert_eq!(row.status, "🗑 Deleting");
+        assert_eq!(row.oldest_record, "1970-01-01T00:00:00Z");
+        assert_eq!(row.latest_record, "1970-01-01T00:00:00Z");
+    }
+
+    #[test]
+    fn test_entry_table_uses_entry_status_for_empty_deleting_entries() {
+        let entry = EntryInfo {
+            name: "left_camera".to_string(),
+            size: 0,
+            record_count: 0,
+            block_count: 0,
+            oldest_record: 0,
+            latest_record: 0,
+            status: ResourceStatus::Deleting,
+        };
+
+        let row = EntryTable::from(entry);
+        assert_eq!(row.status, "🗑 Deleting");
+        assert_eq!(row.oldest_record, "---");
+        assert_eq!(row.latest_record, "---");
     }
 }


### PR DESCRIPTION
Closes #235

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

- stop inferring entry status in `bucket show --full` from `record_count`
- render the actual `entry.status` returned by the API using the existing status formatter
- add regression tests covering `DELETING` entries with both non-zero and zero record counts

### Related issues

- https://github.com/reductstore/reduct-cli/issues/235

### Does this PR introduce a breaking change?

No.

### Other information:

The bug was in the CLI presentation layer only: bucket-level status already used the API status, but entry rows in the full bucket table hardcoded `⚪ Empty` vs `✅ Ready` based only on whether records existed.
