### PR TITLE
Fix cp handling for deleting destination entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.12.2 - 2026-06-18
+
+### Fixed
+
+- Detect destination entries in `Deleting` state before bucket-to-bucket `cp` writes start, and fail late `409 Conflict` writes against deleting entries instead of silently counting them as skipped.
+
 ## 0.12.1 - 2026-06-18
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1489,7 +1489,7 @@ dependencies = [
 
 [[package]]
 name = "reduct-cli"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reduct-cli"
-version = "0.12.1"
+version = "0.12.2"
 edition = "2021"
 authors = ["Alexey Timin <atimin@reduct.store>"]
 rust-version = "1.89.0"

--- a/src/cmd/cp/b2b.rs
+++ b/src/cmd/cp/b2b.rs
@@ -8,7 +8,7 @@ use crate::context::CliContext;
 use crate::io::reduct::build_client;
 use crate::parse::{parse_query_params, Resource};
 use clap::ArgMatches;
-use reduct_rs::{Bucket, ErrorCode, Record, ReductError};
+use reduct_rs::{Bucket, ErrorCode, Record, ReductError, ResourceStatus};
 use serde_json::Value;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
@@ -66,6 +66,16 @@ impl CopyVisitor for CopyToBucketVisitor {
         self.dst_bucket
             .write_attachments(entry_name, attachments)
             .await
+    }
+
+    async fn entry_status(&self, entry_name: &str) -> Result<Option<ResourceStatus>, ReductError> {
+        Ok(self
+            .dst_bucket
+            .entries()
+            .await?
+            .into_iter()
+            .find(|entry| entry.name == entry_name)
+            .map(|entry| entry.status))
     }
 }
 
@@ -130,8 +140,10 @@ pub(crate) async fn cp_bucket_to_bucket_with(
         }
     };
 
+    let destination_entries = dst_bucket.entries().await?;
+    let blocked_entries = build_blocked_entry_errors(&destination_entries);
     let entry_start_overrides = if from_last {
-        Some(build_entry_start_overrides(&dst_bucket).await?)
+        Some(build_entry_start_overrides(&destination_entries))
     } else {
         None
     };
@@ -144,6 +156,7 @@ pub(crate) async fn cp_bucket_to_bucket_with(
         src_bucket,
         query_params,
         entry_start_overrides,
+        blocked_entries,
         dst_bucket_visitor,
     )
     .await
@@ -166,13 +179,30 @@ fn parse_bucket_pair(args: &ArgMatches, key: &str) -> anyhow::Result<(String, St
     }
 }
 
-async fn build_entry_start_overrides(dst_bucket: &Bucket) -> anyhow::Result<HashMap<String, u64>> {
+fn build_blocked_entry_errors(
+    destination_entries: &[reduct_rs::EntryInfo],
+) -> HashMap<String, String> {
+    destination_entries
+        .iter()
+        .filter(|entry| matches!(entry.status, ResourceStatus::Deleting))
+        .map(|entry| {
+            (
+                entry.name.clone(),
+                format!("Destination entry '{}' is being deleted", entry.name),
+            )
+        })
+        .collect()
+}
+
+fn build_entry_start_overrides(
+    destination_entries: &[reduct_rs::EntryInfo],
+) -> HashMap<String, u64> {
     let mut overrides = HashMap::new();
-    for entry in dst_bucket.entries().await? {
+    for entry in destination_entries {
         let start = entry.latest_record.saturating_add(1);
-        overrides.insert(entry.name, start);
+        overrides.insert(entry.name.clone(), start);
     }
-    Ok(overrides)
+    overrides
 }
 
 #[cfg(test)]
@@ -186,6 +216,30 @@ mod tests {
     use rstest::{fixture, rstest};
 
     use super::*;
+
+    #[test]
+    fn test_build_blocked_entry_errors_marks_deleting_entries() {
+        let entries = vec![
+            reduct_rs::EntryInfo {
+                name: "ready".to_string(),
+                status: ResourceStatus::Ready,
+                ..Default::default()
+            },
+            reduct_rs::EntryInfo {
+                name: "deleting".to_string(),
+                status: ResourceStatus::Deleting,
+                ..Default::default()
+            },
+        ];
+
+        let blocked = build_blocked_entry_errors(&entries);
+        assert_eq!(blocked.len(), 1);
+        assert_eq!(
+            blocked.get("deleting").unwrap(),
+            "Destination entry 'deleting' is being deleted"
+        );
+        assert!(!blocked.contains_key("ready"));
+    }
 
     mod copy_visitor {
         use super::*;

--- a/src/cmd/cp/helpers.rs
+++ b/src/cmd/cp/helpers.rs
@@ -11,7 +11,9 @@ use crate::parse::{fetch_and_filter_entries, QueryParams};
 use bytesize::ByteSize;
 use futures_util::StreamExt;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
-use reduct_rs::{condition, Bucket, EntryInfo, ErrorCode, QueryBuilder, Record, ReductError};
+use reduct_rs::{
+    condition, Bucket, EntryInfo, ErrorCode, QueryBuilder, Record, ReductError, ResourceStatus,
+};
 use serde_json::Value;
 use tokio::sync::Mutex as AsyncMutex;
 use tokio::task::JoinSet;
@@ -358,6 +360,10 @@ pub(super) trait CopyVisitor {
     ) -> Result<(), ReductError> {
         Ok(())
     }
+
+    async fn entry_status(&self, _entry_name: &str) -> Result<Option<ResourceStatus>, ReductError> {
+        Ok(None)
+    }
 }
 
 /**
@@ -377,13 +383,21 @@ pub(super) async fn start_loading<V>(
 where
     V: CopyVisitor + Send + Sync + 'static,
 {
-    start_loading_with_entry_start_overrides(src_bucket, query_params, None, dst_bucket_v).await
+    start_loading_with_entry_start_overrides(
+        src_bucket,
+        query_params,
+        None,
+        HashMap::new(),
+        dst_bucket_v,
+    )
+    .await
 }
 
 pub(super) async fn start_loading_with_entry_start_overrides<V>(
     src_bucket: Bucket,
     query_params: QueryParams,
     entry_start_overrides: Option<HashMap<String, u64>>,
+    blocked_entries: HashMap<String, String>,
     dst_bucket_v: V,
 ) -> anyhow::Result<()>
 where
@@ -392,6 +406,16 @@ where
     let entries = fetch_and_filter_entries(&src_bucket, &query_params.entry_filter).await?;
     if entries.is_empty() {
         return Ok(());
+    }
+
+    let mut eligible_entries = Vec::with_capacity(entries.len());
+    let mut blocked_entry_errors = Vec::new();
+    for entry in entries {
+        if let Some(error) = blocked_entries.get(&entry.name) {
+            blocked_entry_errors.push((entry.name.clone(), error.clone()));
+        } else {
+            eligible_entries.push(entry);
+        }
     }
 
     let mut tasks = JoinSet::new();
@@ -408,20 +432,20 @@ where
     let bucket_name = src_bucket.name().to_string();
     let quiet = query_params.quiet;
     let progress_metric = build_progress_metric(
-        &entries,
+        &eligible_entries,
         &query_params,
         entry_start_overrides.as_ref().map(|v| v.as_ref()),
     );
     let bucket_progress = Arc::new(AsyncMutex::new(BucketProgress::new(
         bucket_name,
         display_limit,
-        entries.len(),
+        eligible_entries.len() + blocked_entry_errors.len(),
         progress_metric,
         &progress,
         quiet,
     )));
 
-    for entry in entries {
+    for entry in eligible_entries {
         let local_sem = Arc::clone(&semaphore);
         let local_visitor = Arc::clone(&dst_bucket);
         let params = build_entry_params(&query_params, &entry, entry_start_overrides.as_deref());
@@ -438,8 +462,15 @@ where
         ));
     }
 
-    let mut failed_entries = 0usize;
-    let mut completed_entries = 0usize;
+    {
+        let mut progress = bucket_progress.lock().await;
+        for (entry_name, error) in &blocked_entry_errors {
+            progress.fail_entry(entry_name, error);
+        }
+    }
+
+    let mut failed_entries = blocked_entry_errors.len();
+    let mut completed_entries = blocked_entry_errors.len();
     while let Some(result) = tasks.join_next().await {
         match result {
             Ok(outcome) => {
@@ -819,6 +850,16 @@ async fn flush_batch<V: CopyVisitor + Sync + ?Sized>(
 
         if let Some(err) = errors.get(&ts) {
             if err.status() == ErrorCode::Conflict {
+                if matches!(
+                    visitor.entry_status(entry_name).await?,
+                    Some(ResourceStatus::Deleting)
+                ) {
+                    return Err(ReductError::new(
+                        ErrorCode::Conflict,
+                        "Destination entry is being deleted",
+                    ));
+                }
+
                 let mut progress = bucket_progress.lock().await;
                 progress.skip(entry_name);
             } else if first_error.is_none() {
@@ -1093,6 +1134,7 @@ mod tests {
             #[async_trait]
             impl CopyVisitor for Visitor {
                 async fn copy_records(&self, entry_name: &str, records: Vec<Record>)  -> Result<BTreeMap<u64, ReductError>, ReductError>;
+                async fn entry_status(&self, entry_name: &str) -> Result<Option<ResourceStatus>, ReductError>;
             }
         }
         #[fixture]
@@ -1191,6 +1233,65 @@ mod tests {
                 .withf(|entry, _record| entry == "entry-2")
                 .times(1)
                 .return_const(Ok(BTreeMap::new()));
+            visitor
+                .expect_entry_status()
+                .with(eq("entry-1"))
+                .return_const(Ok(None));
+
+            let result = start_loading(src_bucket, QueryParams::default(), visitor).await;
+            assert!(result.is_ok());
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_downloading_skips_entries_blocked_before_copy(
+            #[future] src_bucket: Bucket,
+            mut visitor: MockVisitor,
+        ) {
+            let src_bucket = src_bucket.await;
+            visitor
+                .expect_copy_records()
+                .times(1)
+                .withf(|entry, _record| entry == "entry-2")
+                .return_const(Ok(BTreeMap::new()));
+
+            let blocked_entries = HashMap::from([(
+                "entry-1".to_string(),
+                "Destination entry 'entry-1' is being deleted".to_string(),
+            )]);
+
+            start_loading_with_entry_start_overrides(
+                src_bucket,
+                QueryParams::default(),
+                None,
+                blocked_entries,
+                visitor,
+            )
+            .await
+            .unwrap();
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_downloading_fails_entry_when_conflict_is_deleting(
+            #[future] src_bucket: Bucket,
+            mut visitor: MockVisitor,
+        ) {
+            let src_bucket = src_bucket.await;
+            visitor
+                .expect_copy_records()
+                .withf(|entry, _record| entry == "entry-1")
+                .times(1)
+                .return_const(Err(ReductError::new(ErrorCode::Conflict, "Conflict")));
+            visitor
+                .expect_copy_records()
+                .withf(|entry, _record| entry == "entry-2")
+                .times(1)
+                .return_const(Ok(BTreeMap::new()));
+            visitor
+                .expect_entry_status()
+                .with(eq("entry-1"))
+                .return_const(Ok(Some(ResourceStatus::Deleting)));
 
             let result = start_loading(src_bucket, QueryParams::default(), visitor).await;
             assert!(result.is_ok());


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix.

### What was changed?

- pre-check destination bucket entries before bucket-to-bucket `cp` starts and mark entries already in `Deleting` state as failed instead of trying to write into them
- keep `--from-last` entry start overrides based on a single destination entry listing pass
- add a race-safe fallback for late `409 Conflict` responses by re-checking destination entry status and failing the entry when it has transitioned to `Deleting`
- bump the CLI version to `0.12.2` and document the fix in `CHANGELOG.md`

### Related issues

- user-reported bucket-to-bucket `cp` against deleting destination entries silently counting all records as skipped after backend `409 Conflict` responses

### Does this PR introduce a breaking change?

No.

### Other information:

Validation performed:
- `cargo test --quiet --no-run`
- `cargo test --quiet test_build_blocked_entry_errors_marks_deleting_entries`
- `cargo test --quiet test_entry_tree_shows_failure_for_entries_without_copied_records`
- `cargo test --quiet test_message_shows_skipped_only_when_non_zero`

Note: the broader `cp` test suite in this environment depends on the local ReductStore test server and was not runnable here without that service.