### PR TITLE
Add command to write a single record with string data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add destination prefixes to replica create, update, and show commands, [PR-247](https://github.com/reductstore/reduct-cli/pull/247) by @ychampion
 - Add compression option to replica create, update, and show commands, [PR-261](https://github.com/reductstore/reduct-cli/pull/261) by @vbmade2000
 - Improve time parsing for --start and --stop options, [PR-226](https://github.com/reductstore/reduct-cli/pull/226) by @yaslam-dev
+- Added `write` command to write a single record to a bucket, [PR-275](https://github.com/reductstore/reduct-cli/pull/275) by @vbmade2000
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1471,6 +1471,8 @@ dependencies = [
  "tempfile",
  "time-humanize",
  "tokio",
+ "tokio-stream",
+ "tokio-util",
  "toml",
  "url",
 ]
@@ -2098,6 +2100,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1463,6 +1463,7 @@ dependencies = [
  "mime_guess",
  "mockall",
  "reduct-rs",
+ "regex",
  "rstest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,8 @@ serde_json = "1.0.150"
 tabled = "0.21.0"
 log = "0.4.31"
 regex = "1.13.1"
+tokio-stream = "0.1.18"
+tokio-util = "0.7.18"
 
 [dev-dependencies]
 rstest = "0.26.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ mime_guess = "2.0.4"
 serde_json = "1.0.150"
 tabled = "0.21.0"
 log = "0.4.31"
+regex = "1.13.1"
 
 [dev-dependencies]
 rstest = "0.26.1"

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -12,6 +12,7 @@ pub(crate) mod rm;
 pub(crate) mod server;
 pub(crate) mod table;
 pub(crate) mod token;
+pub(crate) mod write;
 
 const ALIAS_OR_URL_HELP: &str =
     "Alias or URL (e.g. http://token@localhost:8383) of the ReductStore instance to use";

--- a/src/cmd/write.rs
+++ b/src/cmd/write.rs
@@ -242,67 +242,248 @@ mod tests {
     use reduct_rs::Bucket;
     use rstest::*;
 
-    #[rstest]
-    #[tokio::test]
-    async fn test_write_string_record(
-        context: CliContext,
-        #[future] bucket: Bucket,
-        entry_path: String,
-        payload: String,
-    ) -> anyhow::Result<()> {
-        let bucket = bucket.await;
+    mod file_record_tests {
 
-        // Prepare args
-        let args = write_record_cmd().get_matches_from(vec![
-            "write",
-            format!("local/{}/{}", bucket.name(), entry_path).as_str(),
-            "--string",
-            payload.as_str(),
-        ]);
+        use super::*;
 
-        write_handler(&context, &args).await?;
+        #[rstest]
+        #[tokio::test]
+        async fn test_write_file_with_timestamp(
+            context: CliContext,
+            #[future] bucket: Bucket,
+        ) -> anyhow::Result<()> {
+            let bucket = bucket.await;
 
-        let record = bucket.read_record(&entry_path).send().await?;
+            // Create a test file
+            let temp_dir = tempfile::tempdir()?;
+            let file_path = temp_dir.path().join("testfile");
+            tokio::fs::write(&file_path, b"Hello World").await?;
 
-        assert_eq!(record.bytes().await?, payload.as_bytes());
-        assert_eq!(
-            context.stdout().history(),
-            vec![format!(
-                "Record written to '{}/{}'",
-                bucket.name(),
-                entry_path
-            )]
-        );
+            let timestamp_str = "2026-01-01T01:00:00Z";
+            let args = write_record_cmd().get_matches_from(vec![
+                "write",
+                format!("local/{}/test-entry", bucket.name()).as_str(),
+                "-f",
+                file_path.to_str().unwrap(),
+                "-t",
+                timestamp_str,
+            ]);
 
-        Ok(())
-    }
+            write_handler(&context, &args).await?;
 
-    #[rstest]
-    #[tokio::test]
-    async fn test_write_file_with_mime_guess(
-        context: CliContext,
-        #[future] bucket: Bucket,
-    ) -> anyhow::Result<()> {
-        let bucket = bucket.await;
-        let temp_dir = tempfile::tempdir()?;
-        let file_path = temp_dir.path().join("test.json");
-        tokio::fs::write(&file_path, b"{\"test\": \"data\"}").await?;
+            // Parse the expected timestamp using the same function the handler uses
+            use crate::parse::parse_time;
+            let expected_micros =
+                parse_time(Some(&timestamp_str.to_string()))?.expect("timestamp should parse");
 
-        // Write without explicit content-type, should guess from extension
-        let args = write_record_cmd().get_matches_from(vec![
-            "write",
-            format!("local/{}/test-entry", bucket.name()).as_str(),
-            "--file",
-            file_path.to_str().unwrap(),
-        ]);
+            let record = bucket.read_record("test-entry").send().await?;
+            assert_eq!(record.content_type(), "application/octet-stream");
+            assert_eq!(record.timestamp_us(), expected_micros);
+            assert_eq!(record.bytes().await?.as_ref(), b"Hello World");
 
-        write_handler(&context, &args).await?;
+            Ok(())
+        }
 
-        let record = bucket.read_record("test-entry").send().await?;
-        assert_eq!(record.content_type(), "application/json");
-        assert_eq!(record.bytes().await?.as_ref(), b"{\"test\": \"data\"}");
+        /*
+            Verifies that content-type is set to application/octet-stream
+            when no extension is provided.
+        */
+        #[rstest]
+        #[tokio::test]
+        async fn test_write_file_with_no_extension(
+            context: CliContext,
+            #[future] bucket: Bucket,
+        ) -> anyhow::Result<()> {
+            let bucket = bucket.await;
 
-        Ok(())
+            // Create an empty file
+            let temp_dir = tempfile::tempdir()?;
+            let file_path = temp_dir.path().join("testfile");
+            tokio::fs::write(&file_path, b"Hello World").await?;
+
+            let args = write_record_cmd().get_matches_from(vec![
+                "write",
+                format!("local/{}/test-entry", bucket.name()).as_str(),
+                "-f",
+                file_path.to_str().unwrap(),
+            ]);
+
+            write_handler(&context, &args).await?;
+
+            let record = bucket.read_record("test-entry").send().await?;
+            assert_eq!(record.content_type(), "application/octet-stream");
+
+            Ok(())
+        }
+
+        /*
+            Verifies that an error is returned when writing an empty file.
+        */
+        #[rstest]
+        #[tokio::test]
+        async fn test_write_file_with_empty_file(
+            context: CliContext,
+            #[future] bucket: Bucket,
+        ) -> anyhow::Result<()> {
+            let bucket = bucket.await;
+
+            // Create an empty file
+            let temp_dir = tempfile::tempdir()?;
+            let file_path = temp_dir.path().join("test.txt");
+            tokio::fs::write(&file_path, b"").await?;
+
+            let args = write_record_cmd().get_matches_from(vec![
+                "write",
+                format!("local/{}/test-entry", bucket.name()).as_str(),
+                "-f",
+                file_path.to_str().unwrap(),
+            ]);
+
+            let result = write_handler(&context, &args).await;
+
+            assert!(result.is_err());
+
+            let error_msg = result.unwrap_err().to_string();
+            assert!(
+                error_msg.contains("File is empty"),
+                "Expected error about empty file, got: {}",
+                error_msg
+            );
+
+            Ok(())
+        }
+
+        /*
+            Verifies that the content-type is guessed from the file extension
+            when --content-type is not supplied.
+        */
+        #[rstest]
+        #[tokio::test]
+        async fn test_write_file_with_mime_guess(
+            context: CliContext,
+            #[future] bucket: Bucket,
+        ) -> anyhow::Result<()> {
+            let bucket = bucket.await;
+            let temp_dir = tempfile::tempdir()?;
+            let file_path = temp_dir.path().join("test.json");
+            tokio::fs::write(&file_path, b"{\"test\": \"data\"}").await?;
+
+            // Write without explicit content-type, should guess from extension
+            let args = write_record_cmd().get_matches_from(vec![
+                "write",
+                format!("local/{}/test-entry", bucket.name()).as_str(),
+                "--file",
+                file_path.to_str().unwrap(),
+            ]);
+
+            write_handler(&context, &args).await?;
+
+            let record = bucket.read_record("test-entry").send().await?;
+            assert_eq!(record.content_type(), "application/json");
+            assert_eq!(record.bytes().await?.as_ref(), b"{\"test\": \"data\"}");
+
+            Ok(())
+        }
+
+        /*
+            Verifies that the content-type is set to the value supplied
+            when --content-type is used.
+        */
+        #[rstest]
+        #[tokio::test]
+        async fn test_write_file_with_content_type(
+            context: CliContext,
+            #[future] bucket: Bucket,
+        ) -> anyhow::Result<()> {
+            let bucket = bucket.await;
+            let temp_dir = tempfile::tempdir()?;
+            let file_path = temp_dir.path().join("test.txt");
+            tokio::fs::write(&file_path, b"hello world").await?;
+
+            // Write without explicit content-type, should guess from extension
+            let args = write_record_cmd().get_matches_from(vec![
+                "write",
+                format!("local/{}/test-entry", bucket.name()).as_str(),
+                "--file",
+                file_path.to_str().unwrap(),
+                "--content-type",
+                "application/json",
+            ]);
+
+            write_handler(&context, &args).await?;
+
+            let record = bucket.read_record("test-entry").send().await?;
+            assert_eq!(record.content_type(), "application/json");
+
+            Ok(())
+        }
+
+        /*
+            Verifies that an error is returned when the file is not found.
+        */
+        #[rstest]
+        #[tokio::test]
+        async fn test_file_not_found(
+            context: CliContext,
+            #[future] bucket: Bucket,
+        ) -> anyhow::Result<()> {
+            let file_path = "not_exist.json";
+            let bucket = bucket.await;
+
+            let args = write_record_cmd().get_matches_from(vec![
+                "write",
+                format!("local/{}/test-entry", bucket.name()).as_str(),
+                "-f",
+                file_path,
+            ]);
+
+            let result = write_handler(&context, &args).await;
+
+            // Should return an error for non-existent file
+            assert!(result.is_err());
+            let error_msg = result.unwrap_err().to_string();
+            assert!(
+                error_msg.contains("No such file or directory"),
+                "Expected error about missing file, got: {}",
+                error_msg
+            );
+
+            Ok(())
+        }
+
+        /*
+            Verifies that an error is returned when a directory is passed
+            instead of a file.
+        */
+        #[rstest]
+        #[tokio::test]
+        async fn test_dir_path_for_file(
+            context: CliContext,
+            #[future] bucket: Bucket,
+        ) -> anyhow::Result<()> {
+            let file_path = "/tmp/somedir";
+            let bucket = bucket.await;
+
+            let args = write_record_cmd().get_matches_from(vec![
+                "write",
+                format!("local/{}/test-entry", bucket.name()).as_str(),
+                "-f",
+                file_path,
+            ]);
+
+            let result = write_handler(&context, &args).await;
+
+            // Should return an error for non-existent file
+            assert!(result.is_err());
+            let error_msg = result.unwrap_err().to_string();
+            assert!(
+                error_msg.contains("No such file or directory"),
+                "Expected error about missing file, got: {}",
+                error_msg
+            );
+
+            Ok(())
+        }
     }
 
     #[fixture]

--- a/src/cmd/write.rs
+++ b/src/cmd/write.rs
@@ -1,6 +1,7 @@
 use clap::{Arg, Command};
+use regex::Regex;
 
-use crate::context::CliContext;
+use crate::{context::CliContext, io::reduct::build_client};
 
 pub(crate) fn write_cmd() -> Command {
     Command::new("write")
@@ -21,17 +22,30 @@ pub(crate) fn write_cmd() -> Command {
         )
 }
 
-pub(crate) async fn write_handler(
-    _ctx: &CliContext,
-    args: &clap::ArgMatches,
-) -> anyhow::Result<()> {
+pub(crate) async fn write_handler(ctx: &CliContext, args: &clap::ArgMatches) -> anyhow::Result<()> {
     println!("write_handler");
 
     let entry_path = args.get_one::<String>("ENTRY_PATH").unwrap().clone();
+    let (alias_or_url, bucket_name, entry_name) = parse_entry_path(&entry_path)?;
     let payload = args.get_one::<String>("payload").unwrap().clone();
 
-    println!("{:?}", entry_path);
-    println!("{:?}", payload);
+    let client = build_client(ctx, &alias_or_url).await?;
 
     Ok(())
+}
+
+fn parse_entry_path(entry_path: &str) -> anyhow::Result<(String, String, String)> {
+    let re = Regex::new(r"^(?P<alias_or_url>[^/]+)/(?P<bucket_name>[^/]+)/(?P<entry_name>.+)$")?;
+    let caps = re.captures(entry_path).ok_or_else(|| {
+        anyhow::anyhow!(
+            "Invalid entry path. Expected ALIAS/BUCKET/ENTRY, got {}",
+            entry_path
+        )
+    })?;
+
+    let alias_or_url = caps.name("alias_or_url").unwrap().as_str().to_string();
+    let bucket_name = caps.name("bucket_name").unwrap().as_str().to_string();
+    let entry_name = caps.name("entry_name").unwrap().as_str().to_string();
+
+    Ok((alias_or_url, bucket_name, entry_name))
 }

--- a/src/cmd/write.rs
+++ b/src/cmd/write.rs
@@ -1,5 +1,6 @@
 use clap::{Arg, Command};
 use reduct_rs::Labels;
+use tokio_util::io::ReaderStream;
 
 use crate::{
     context::CliContext,
@@ -43,27 +44,37 @@ pub(crate) async fn write_handler(ctx: &CliContext, args: &clap::ArgMatches) -> 
     let entry_name = entry_name
         .ok_or_else(|| anyhow::anyhow!("ENTRY_PATH must be alias/bucket/path/to/entry"))?;
 
-    let mut is_file = false;
-    let data = if let Some(path) = args.get_one::<String>("path") {
-        is_file = true;
-        std::fs::read(path)?
-    } else {
-        args.get_one::<String>("payload")
-            .unwrap()
-            .as_bytes()
-            .to_vec()
-    };
-
     let client = build_client(ctx, &alias_or_url).await?;
 
     let bucket = client.get_bucket(&bucket_name).await?;
-    bucket
-        .write_record(&entry_name)
-        .data(data)
-        .content_type("application/text")
-        .labels(Labels::from([("is_file".to_string(), is_file.to_string())]))
-        .send()
-        .await?;
+
+    if let Some(path) = args.get_one::<String>("path") {
+        let reader_stream = ReaderStream::new(tokio::fs::File::open(path).await?);
+        let content_length = tokio::fs::metadata(path).await?.len();
+        bucket
+            .write_record(&entry_name)
+            // .content_type("application/text")
+            .labels(Labels::from([("name".to_string(), "malhar".to_string())]))
+            .stream(reader_stream)
+            .content_length(content_length)
+            .send()
+            .await?;
+    } else {
+        println!("found payload");
+        let data = args
+            .get_one::<String>("payload")
+            .unwrap()
+            .as_bytes()
+            .to_vec();
+        // ReaderStream::new(bytes.as_slice())
+        bucket
+            .write_record(&entry_name)
+            .data(data)
+            .content_type("application/text")
+            .labels(Labels::from([("is_file".to_string(), "false".to_string())]))
+            .send()
+            .await?;
+    };
 
     output!(ctx, "Record written to '{}/{}'", bucket_name, entry_name);
 

--- a/src/cmd/write.rs
+++ b/src/cmd/write.rs
@@ -242,6 +242,78 @@ mod tests {
     use reduct_rs::Bucket;
     use rstest::*;
 
+    mod string_record_tests {
+
+        use super::*;
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_write_string_record(
+            context: CliContext,
+            #[future] bucket: Bucket,
+            entry_path: String,
+            payload: String,
+        ) -> anyhow::Result<()> {
+            let bucket = bucket.await;
+
+            // Prepare args
+            let args = write_record_cmd().get_matches_from(vec![
+                "write",
+                format!("local/{}/{}", bucket.name(), entry_path).as_str(),
+                "--string",
+                payload.as_str(),
+            ]);
+
+            write_handler(&context, &args).await?;
+
+            let record = bucket.read_record(&entry_path).send().await?;
+
+            assert_eq!(record.bytes().await?, payload.as_bytes());
+
+            assert_eq!(
+                context.stdout().history(),
+                vec![format!(
+                    "Record written to '{}/{}'",
+                    bucket.name(),
+                    entry_path
+                )]
+            );
+
+            Ok(())
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_write_string_record_with_content_type(
+            context: CliContext,
+            #[future] bucket: Bucket,
+            entry_path: String,
+            payload: String,
+        ) -> anyhow::Result<()> {
+            let bucket = bucket.await;
+
+            let content_type = "text/html";
+
+            // Prepare args
+            let args = write_record_cmd().get_matches_from(vec![
+                "write",
+                format!("local/{}/{}", bucket.name(), entry_path).as_str(),
+                "--string",
+                payload.as_str(),
+                "--content-type",
+                content_type,
+            ]);
+
+            write_handler(&context, &args).await?;
+
+            let record = bucket.read_record(&entry_path).send().await?;
+
+            assert_eq!(record.content_type(), content_type);
+
+            Ok(())
+        }
+    }
+
     mod file_record_tests {
 
         use super::*;
@@ -522,6 +594,196 @@ mod tests {
                 expected_errors,
                 error_msg
             );
+
+            Ok(())
+        }
+    }
+
+    mod label_tests {
+        use super::*;
+
+        /*
+            Test writing records with valid label formats.
+            Tests: key=value format, multiple labels, and JSON format.
+        */
+        #[rstest]
+        #[case("env=prod", &[("env", "prod")])]
+        #[case("env=prod,version=1.0", &[("env", "prod"), ("version", "1.0")])]
+        #[case("key1=value1,key2=value2,key3=value3", &[("key1", "value1"), ("key2", "value2"), ("key3", "value3")])]
+        #[case(r#"{"env":"prod"}"#, &[("env", "prod")])]
+        #[case(r#"{"env":"prod","version":"1.0"}"#, &[("env", "prod"), ("version", "1.0")])]
+        #[tokio::test]
+        async fn test_write_string_with_valid_labels(
+            context: CliContext,
+            #[future] bucket: Bucket,
+            #[case] labels_str: &str,
+            #[case] expected_labels: &[(&str, &str)],
+        ) -> anyhow::Result<()> {
+            let bucket = bucket.await;
+
+            let args = write_record_cmd().get_matches_from(vec![
+                "write",
+                format!("local/{}/test-entry", bucket.name()).as_str(),
+                "-s",
+                "test payload",
+                "--labels",
+                labels_str,
+            ]);
+
+            write_handler(&context, &args).await?;
+
+            let record = bucket.read_record("test-entry").send().await?;
+            let labels = record.labels();
+
+            // Check all expected labels are present
+            for (key, value) in expected_labels {
+                assert_eq!(
+                    labels.get(*key),
+                    Some(&value.to_string()),
+                    "Expected label {}={}, but got {:?}",
+                    key,
+                    value,
+                    labels.get(*key)
+                );
+            }
+
+            // Check count matches
+            assert_eq!(
+                labels.len(),
+                expected_labels.len(),
+                "Expected {} labels, got {}",
+                expected_labels.len(),
+                labels.len()
+            );
+
+            Ok(())
+        }
+
+        /*
+            Test that invalid label formats are rejected.
+        */
+        #[rstest]
+        #[case("invalid", "Invalid label format")]
+        #[case("=value", "Label key cannot be empty")]
+        #[case("key1=value1,invalid", "Invalid label format")]
+        #[case(r#"{"invalid json"#, "Failed to parse labels as JSON")]
+        #[tokio::test]
+        async fn test_write_with_invalid_labels(
+            context: CliContext,
+            #[future] bucket: Bucket,
+            #[case] labels_str: &str,
+            #[case] expected_error: &str,
+        ) -> anyhow::Result<()> {
+            let bucket = bucket.await;
+
+            let args = write_record_cmd().get_matches_from(vec![
+                "write",
+                format!("local/{}/test-entry", bucket.name()).as_str(),
+                "-s",
+                "test payload",
+                "--labels",
+                labels_str,
+            ]);
+
+            let result = write_handler(&context, &args).await;
+
+            assert!(result.is_err());
+            let error_msg = result.unwrap_err().to_string();
+            assert!(
+                error_msg.contains(expected_error),
+                "Expected error containing '{}', got: {}",
+                expected_error,
+                error_msg
+            );
+
+            Ok(())
+        }
+
+        /*
+            Test that empty label values are allowed.
+        */
+        #[rstest]
+        #[tokio::test]
+        async fn test_write_with_empty_label_value(
+            context: CliContext,
+            #[future] bucket: Bucket,
+        ) -> anyhow::Result<()> {
+            let bucket = bucket.await;
+
+            let args = write_record_cmd().get_matches_from(vec![
+                "write",
+                format!("local/{}/test-entry", bucket.name()).as_str(),
+                "-s",
+                "test payload",
+                "--labels",
+                "key=",
+            ]);
+
+            write_handler(&context, &args).await?;
+
+            let record = bucket.read_record("test-entry").send().await?;
+            let labels = record.labels();
+
+            assert_eq!(labels.get("key"), Some(&"".to_string()));
+
+            Ok(())
+        }
+
+        /*
+            Test that labels with special characters work correctly.
+        */
+        #[rstest]
+        #[tokio::test]
+        async fn test_write_with_special_char_labels(
+            context: CliContext,
+            #[future] bucket: Bucket,
+        ) -> anyhow::Result<()> {
+            let bucket = bucket.await;
+
+            let args = write_record_cmd().get_matches_from(vec![
+                "write",
+                format!("local/{}/test-entry", bucket.name()).as_str(),
+                "-s",
+                "test payload",
+                "--labels",
+                "key-1=value_1,key.2=value-2",
+            ]);
+
+            write_handler(&context, &args).await?;
+
+            let record = bucket.read_record("test-entry").send().await?;
+            let labels = record.labels();
+
+            assert_eq!(labels.get("key-1"), Some(&"value_1".to_string()));
+            assert_eq!(labels.get("key.2"), Some(&"value-2".to_string()));
+
+            Ok(())
+        }
+
+        /*
+            Test writing without labels (labels should be empty).
+        */
+        #[rstest]
+        #[tokio::test]
+        async fn test_write_without_labels(
+            context: CliContext,
+            #[future] bucket: Bucket,
+        ) -> anyhow::Result<()> {
+            let bucket = bucket.await;
+
+            let args = write_record_cmd().get_matches_from(vec![
+                "write",
+                format!("local/{}/test-entry", bucket.name()).as_str(),
+                "-s",
+                "test payload",
+            ]);
+
+            write_handler(&context, &args).await?;
+
+            let record = bucket.read_record("test-entry").send().await?;
+            let labels = record.labels();
+
+            assert!(labels.is_empty(), "Expected no labels, got: {:?}", labels);
 
             Ok(())
         }

--- a/src/cmd/write.rs
+++ b/src/cmd/write.rs
@@ -1,0 +1,20 @@
+use clap::{Arg, Command};
+
+pub(crate) fn write_cmd() -> Command {
+    Command::new("write")
+        .about("Write single record to a bucket")
+        .arg(
+            Arg::new("entry-path")
+                .help("Full path the entry to write to")
+                .required(true),
+        )
+        .arg(
+            Arg::new("payload")
+                .long("string")
+                .short('s')
+                .help("inline payload string.")
+                .required(false)
+                .value_name("PAYLOAD")
+                .conflicts_with("path"),
+        )
+}

--- a/src/cmd/write.rs
+++ b/src/cmd/write.rs
@@ -1,7 +1,10 @@
 use clap::{Arg, Command};
 use regex::Regex;
 
-use crate::{context::CliContext, io::reduct::build_client};
+use crate::{
+    context::CliContext,
+    io::{reduct::build_client, std::output},
+};
 
 pub(crate) fn write_cmd() -> Command {
     Command::new("write")
@@ -23,13 +26,21 @@ pub(crate) fn write_cmd() -> Command {
 }
 
 pub(crate) async fn write_handler(ctx: &CliContext, args: &clap::ArgMatches) -> anyhow::Result<()> {
-    println!("write_handler");
-
     let entry_path = args.get_one::<String>("ENTRY_PATH").unwrap().clone();
     let (alias_or_url, bucket_name, entry_name) = parse_entry_path(&entry_path)?;
     let payload = args.get_one::<String>("payload").unwrap().clone();
 
     let client = build_client(ctx, &alias_or_url).await?;
+
+    let bucket = client.get_bucket(&bucket_name).await?;
+    bucket
+        .write_record(&entry_name)
+        .data(payload)
+        .content_type("application/text")
+        .send()
+        .await?;
+
+    output!(ctx, "Record written to '{}/{}' ", bucket_name, entry_name);
 
     Ok(())
 }

--- a/src/cmd/write.rs
+++ b/src/cmd/write.rs
@@ -1,10 +1,12 @@
 use clap::{Arg, Command};
 
+use crate::context::CliContext;
+
 pub(crate) fn write_cmd() -> Command {
     Command::new("write")
         .about("Write single record to a bucket")
         .arg(
-            Arg::new("entry-path")
+            Arg::new("ENTRY_PATH")
                 .help("Full path the entry to write to")
                 .required(true),
         )
@@ -13,8 +15,23 @@ pub(crate) fn write_cmd() -> Command {
                 .long("string")
                 .short('s')
                 .help("inline payload string.")
-                .required(false)
+                .required(true)
                 .value_name("PAYLOAD")
                 .conflicts_with("path"),
         )
+}
+
+pub(crate) async fn write_handler(
+    _ctx: &CliContext,
+    args: &clap::ArgMatches,
+) -> anyhow::Result<()> {
+    println!("write_handler");
+
+    let entry_path = args.get_one::<String>("ENTRY_PATH").unwrap().clone();
+    let payload = args.get_one::<String>("payload").unwrap().clone();
+
+    println!("{:?}", entry_path);
+    println!("{:?}", payload);
+
+    Ok(())
 }

--- a/src/cmd/write.rs
+++ b/src/cmd/write.rs
@@ -91,6 +91,13 @@ pub(crate) fn write_record_cmd() -> Command {
                 .help("RFC 3339 / ISO timestamp or Unix timestamp in microseconds.")
                 .required(false)
                 .value_name("TIME"),
+        ).arg(
+            Arg::new("quiet")
+                .long("quiet")
+                .short('q')
+                .help("suppress successful output.")
+                .required(false)
+                .action(clap::ArgAction::SetTrue),
         )
 }
 
@@ -160,7 +167,9 @@ pub(crate) async fn write_handler(ctx: &CliContext, args: &clap::ArgMatches) -> 
         write_record_builder.data(data).send().await?;
     };
 
-    output!(ctx, "Record written to '{}/{}'", bucket_name, entry_name);
+    if !args.get_flag("quiet") {
+        output!(ctx, "Record written to '{}/{}'", bucket_name, entry_name);
+    }
 
     Ok(())
 }

--- a/src/cmd/write.rs
+++ b/src/cmd/write.rs
@@ -3,59 +3,18 @@ use bytesize::ByteSize;
 use clap::{Arg, Command};
 use futures_util::stream::Stream;
 use indicatif::{ProgressBar, ProgressStyle};
-use reduct_rs::{Labels, WriteRecordBuilder};
-use std::collections::HashMap;
+use reduct_rs::WriteRecordBuilder;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::SystemTime;
 use tokio_util::io::ReaderStream;
 
-use crate::parse::parse_time;
+use crate::parse::{parse_labels, parse_time};
 use crate::{
     context::CliContext,
     io::{reduct::build_client, std::output},
     parse::{Resource, ResourcePathParser},
 };
-
-/// Parse labels from either key=value,key=value format or JSON object format
-fn parse_labels(labels_str: &str) -> anyhow::Result<Labels> {
-    let trimmed = labels_str.trim();
-
-    // Try to parse as JSON first
-    if trimmed.starts_with('{') {
-        let labels_map: HashMap<String, String> = serde_json::from_str(trimmed)
-            .map_err(|e| anyhow::anyhow!("Failed to parse labels as JSON: {}", e))?;
-        return Ok(labels_map);
-    }
-
-    // Parse as key=value,key=value format
-    let mut labels = HashMap::new();
-    for pair in trimmed.split(',') {
-        let pair = pair.trim();
-        if pair.is_empty() {
-            continue;
-        }
-
-        let parts: Vec<&str> = pair.splitn(2, '=').collect();
-        if parts.len() != 2 {
-            return Err(anyhow::anyhow!(
-                "Invalid label format '{}': expected key=value",
-                pair
-            ));
-        }
-
-        let key = parts[0].trim();
-        let value = parts[1].trim();
-
-        if key.is_empty() {
-            return Err(anyhow::anyhow!("Label key cannot be empty in '{}'", pair));
-        }
-
-        labels.insert(key.to_string(), value.to_string());
-    }
-
-    Ok(labels)
-}
 
 /// A wrapper stream that tracks upload progress
 struct ProgressStream<S> {
@@ -369,74 +328,5 @@ mod tests {
             .unwrap()
             .as_nanos();
         format!("{}-{}", prefix, nanos)
-    }
-
-    #[test]
-    fn test_parse_labels_key_value_format() {
-        let labels = parse_labels("key1=value1,key2=value2").unwrap();
-        assert_eq!(labels.len(), 2);
-        assert_eq!(labels.get("key1"), Some(&"value1".to_string()));
-        assert_eq!(labels.get("key2"), Some(&"value2".to_string()));
-    }
-
-    #[test]
-    fn test_parse_labels_key_value_with_spaces() {
-        let labels = parse_labels(" key1 = value1 , key2 = value2 ").unwrap();
-        assert_eq!(labels.len(), 2);
-        assert_eq!(labels.get("key1"), Some(&"value1".to_string()));
-        assert_eq!(labels.get("key2"), Some(&"value2".to_string()));
-    }
-
-    #[test]
-    fn test_parse_labels_json_format() {
-        let labels = parse_labels(r#"{"key1":"value1","key2":"value2"}"#).unwrap();
-        assert_eq!(labels.len(), 2);
-        assert_eq!(labels.get("key1"), Some(&"value1".to_string()));
-        assert_eq!(labels.get("key2"), Some(&"value2".to_string()));
-    }
-
-    #[test]
-    fn test_parse_labels_empty_value() {
-        let labels = parse_labels("key1=,key2=value2").unwrap();
-        assert_eq!(labels.len(), 2);
-        assert_eq!(labels.get("key1"), Some(&"".to_string()));
-        assert_eq!(labels.get("key2"), Some(&"value2".to_string()));
-    }
-
-    #[test]
-    fn test_parse_labels_value_with_equals() {
-        let labels = parse_labels("key1=value=with=equals").unwrap();
-        assert_eq!(labels.len(), 1);
-        assert_eq!(labels.get("key1"), Some(&"value=with=equals".to_string()));
-    }
-
-    #[test]
-    fn test_parse_labels_invalid_format() {
-        let result = parse_labels("invalid");
-        assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("expected key=value"));
-    }
-
-    #[test]
-    fn test_parse_labels_empty_key() {
-        let result = parse_labels("=value");
-        assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("key cannot be empty"));
-    }
-
-    #[test]
-    fn test_parse_labels_invalid_json() {
-        let result = parse_labels(r#"{"key1":"value1""#);
-        assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Failed to parse labels as JSON"));
     }
 }

--- a/src/cmd/write.rs
+++ b/src/cmd/write.rs
@@ -526,39 +526,6 @@ mod tests {
         }
 
         /*
-            Test writing string records with a timestamp.
-        */
-        #[rstest]
-        #[tokio::test]
-        async fn test_write_string_with_timestamp(
-            context: CliContext,
-            #[future] bucket: Bucket,
-        ) -> anyhow::Result<()> {
-            let bucket = bucket.await;
-
-            let timestamp_str = "2025-12-25T12:00:00Z";
-            let args = write_record_cmd().get_matches_from(vec![
-                "write",
-                format!("local/{}/test-entry", bucket.name()).as_str(),
-                "-s",
-                "test payload",
-                "-t",
-                timestamp_str,
-            ]);
-
-            write_handler(&context, &args).await?;
-
-            let expected_micros =
-                parse_time(Some(&timestamp_str.to_string()))?.expect("timestamp should parse");
-
-            let record = bucket.read_record("test-entry").send().await?;
-            assert_eq!(record.timestamp_us(), expected_micros);
-            assert_eq!(record.bytes().await?.as_ref(), b"test payload");
-
-            Ok(())
-        }
-
-        /*
             Test that writing without a timestamp uses the current time.
         */
         #[rstest]

--- a/src/cmd/write.rs
+++ b/src/cmd/write.rs
@@ -246,44 +246,6 @@ mod tests {
 
         use super::*;
 
-        #[rstest]
-        #[tokio::test]
-        async fn test_write_file_with_timestamp(
-            context: CliContext,
-            #[future] bucket: Bucket,
-        ) -> anyhow::Result<()> {
-            let bucket = bucket.await;
-
-            // Create a test file
-            let temp_dir = tempfile::tempdir()?;
-            let file_path = temp_dir.path().join("testfile");
-            tokio::fs::write(&file_path, b"Hello World").await?;
-
-            let timestamp_str = "2026-01-01T01:00:00Z";
-            let args = write_record_cmd().get_matches_from(vec![
-                "write",
-                format!("local/{}/test-entry", bucket.name()).as_str(),
-                "-f",
-                file_path.to_str().unwrap(),
-                "-t",
-                timestamp_str,
-            ]);
-
-            write_handler(&context, &args).await?;
-
-            // Parse the expected timestamp using the same function the handler uses
-            use crate::parse::parse_time;
-            let expected_micros =
-                parse_time(Some(&timestamp_str.to_string()))?.expect("timestamp should parse");
-
-            let record = bucket.read_record("test-entry").send().await?;
-            assert_eq!(record.content_type(), "application/octet-stream");
-            assert_eq!(record.timestamp_us(), expected_micros);
-            assert_eq!(record.bytes().await?.as_ref(), b"Hello World");
-
-            Ok(())
-        }
-
         /*
             Verifies that content-type is set to application/octet-stream
             when no extension is provided.
@@ -479,6 +441,164 @@ mod tests {
             assert!(
                 error_msg.contains("No such file or directory"),
                 "Expected error about missing file, got: {}",
+                error_msg
+            );
+
+            Ok(())
+        }
+    }
+
+    mod timestamp_tests {
+        use super::*;
+        use crate::parse::parse_time;
+
+        /*
+            Test writing records with valid timestamp formats.
+            Tests RFC 3339 UTC, RFC 3339 with offset, and Unix microseconds.
+        */
+        #[rstest]
+        #[case("2026-01-01T01:00:00Z", "RFC 3339 UTC")]
+        #[case("2025-06-15T14:30:00+05:30", "RFC 3339 with offset")]
+        #[case("1672531200000000", "Unix microseconds")]
+        #[tokio::test]
+        async fn test_write_file_with_valid_timestamps(
+            context: CliContext,
+            #[future] bucket: Bucket,
+            #[case] timestamp_str: &str,
+            #[case] _description: &str,
+        ) -> anyhow::Result<()> {
+            let bucket = bucket.await;
+
+            let temp_dir = tempfile::tempdir()?;
+            let file_path = temp_dir.path().join("testfile");
+            tokio::fs::write(&file_path, b"test data").await?;
+
+            let args = write_record_cmd().get_matches_from(vec![
+                "write",
+                format!("local/{}/test-entry", bucket.name()).as_str(),
+                "-f",
+                file_path.to_str().unwrap(),
+                "-t",
+                timestamp_str,
+            ]);
+
+            write_handler(&context, &args).await?;
+
+            let expected_micros =
+                parse_time(Some(&timestamp_str.to_string()))?.expect("timestamp should parse");
+
+            let record = bucket.read_record("test-entry").send().await?;
+            assert_eq!(record.timestamp_us(), expected_micros);
+
+            Ok(())
+        }
+
+        /*
+            Test writing string records with a timestamp.
+        */
+        #[rstest]
+        #[tokio::test]
+        async fn test_write_string_with_timestamp(
+            context: CliContext,
+            #[future] bucket: Bucket,
+        ) -> anyhow::Result<()> {
+            let bucket = bucket.await;
+
+            let timestamp_str = "2025-12-25T12:00:00Z";
+            let args = write_record_cmd().get_matches_from(vec![
+                "write",
+                format!("local/{}/test-entry", bucket.name()).as_str(),
+                "-s",
+                "test payload",
+                "-t",
+                timestamp_str,
+            ]);
+
+            write_handler(&context, &args).await?;
+
+            let expected_micros =
+                parse_time(Some(&timestamp_str.to_string()))?.expect("timestamp should parse");
+
+            let record = bucket.read_record("test-entry").send().await?;
+            assert_eq!(record.timestamp_us(), expected_micros);
+            assert_eq!(record.bytes().await?.as_ref(), b"test payload");
+
+            Ok(())
+        }
+
+        /*
+            Test that writing without a timestamp uses the current time.
+        */
+        #[rstest]
+        #[tokio::test]
+        async fn test_write_without_timestamp_uses_current_time(
+            context: CliContext,
+            #[future] bucket: Bucket,
+        ) -> anyhow::Result<()> {
+            let bucket = bucket.await;
+
+            let before_us = SystemTime::now().duration_since(UNIX_EPOCH)?.as_micros() as u64;
+
+            let args = write_record_cmd().get_matches_from(vec![
+                "write",
+                format!("local/{}/test-entry", bucket.name()).as_str(),
+                "-s",
+                "test payload",
+            ]);
+
+            write_handler(&context, &args).await?;
+
+            let after_us = SystemTime::now().duration_since(UNIX_EPOCH)?.as_micros() as u64;
+
+            let record = bucket.read_record("test-entry").send().await?;
+            let timestamp = record.timestamp_us();
+
+            // Timestamp should be between before and after
+            assert!(
+                timestamp >= before_us && timestamp <= after_us,
+                "Timestamp {} should be between {} and {}",
+                timestamp,
+                before_us,
+                after_us
+            );
+
+            Ok(())
+        }
+
+        /*
+            Test that invalid timestamp formats are rejected.
+            Tests: invalid format, empty string, and pre-epoch timestamps.
+        */
+        #[rstest]
+        #[case("invalid-timestamp", &["Invalid timestamp", "Failed to parse"])]
+        #[case("   ", &["Invalid timestamp", "empty"])]
+        #[case("1969-12-31T23:59:59Z", &["Invalid timestamp", "Unix epoch"])]
+        #[tokio::test]
+        async fn test_write_with_invalid_timestamps(
+            context: CliContext,
+            #[future] bucket: Bucket,
+            #[case] timestamp_str: &str,
+            #[case] expected_errors: &[&str],
+        ) -> anyhow::Result<()> {
+            let bucket = bucket.await;
+
+            let args = write_record_cmd().get_matches_from(vec![
+                "write",
+                format!("local/{}/test-entry", bucket.name()).as_str(),
+                "-s",
+                "test payload",
+                "-t",
+                timestamp_str,
+            ]);
+
+            let result = write_handler(&context, &args).await;
+
+            assert!(result.is_err());
+            let error_msg = result.unwrap_err().to_string();
+            assert!(
+                expected_errors.iter().any(|e| error_msg.contains(e)),
+                "Expected one of {:?} in error, got: {}",
+                expected_errors,
                 error_msg
             );
 

--- a/src/cmd/write.rs
+++ b/src/cmd/write.rs
@@ -3,7 +3,7 @@ use bytesize::ByteSize;
 use clap::{Arg, Command};
 use futures_util::stream::Stream;
 use indicatif::{ProgressBar, ProgressStyle};
-use reduct_rs::Labels;
+use reduct_rs::WriteRecordBuilder;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use tokio_util::io::ReaderStream;
@@ -70,7 +70,7 @@ pub(crate) fn write_record_cmd() -> Command {
                 .long("file")
                 .short('f')
                 .help("payload file path.")
-                .required(false)
+                .required(true)
                 .value_name("PATH")
                 .conflicts_with("payload"),
         )
@@ -84,58 +84,72 @@ pub(crate) async fn write_handler(ctx: &CliContext, args: &clap::ArgMatches) -> 
         .ok_or_else(|| anyhow::anyhow!("ENTRY_PATH must be alias/bucket/path/to/entry"))?;
 
     let client = build_client(ctx, &alias_or_url).await?;
-
     let bucket = client.get_bucket(&bucket_name).await?;
+    let write_record_builder = bucket.write_record(&entry_name);
+    // .labels(labels)
+    // .content_type(content_type)
+    // .timestamp_us(timestamp)
+    // .content_type("application/text")
 
     if let Some(path) = args.get_one::<String>("path") {
-        let reader_stream = ReaderStream::new(tokio::fs::File::open(path).await?);
-        let content_length = tokio::fs::metadata(path).await?.len();
-
-        // Create a progress bar for file upload
-        let progress_bar = ProgressBar::new(content_length);
-        progress_bar.set_style(
-            ProgressStyle::with_template(
-                "[{elapsed_precise}] {bar:40.green/gray} {bytes}/{total_bytes} ({bytes_per_sec}) {msg}",
-            )?
-            .tick_strings(&["▁", "▃", "▄", "▅", "▆", "▇"]),
-        );
-        progress_bar.set_message(format!("Uploading to {}/{}", bucket_name, entry_name));
-
-        // Wrap the stream with progress tracking
-        let progress_stream = ProgressStream::new(reader_stream, progress_bar.clone());
-
-        bucket
-            .write_record(&entry_name)
-            // .content_type("application/text")
-            .labels(Labels::from([("name".to_string(), "malhar".to_string())]))
-            .stream(progress_stream)
-            .content_length(content_length)
-            .send()
-            .await?;
-
-        progress_bar.finish_with_message(format!(
-            "Uploaded {} to {}/{}",
-            ByteSize::b(content_length),
-            bucket_name,
-            entry_name
-        ));
+        write_file_record(ctx, &bucket_name, &entry_name, path, write_record_builder).await?;
     } else {
         let data = args
             .get_one::<String>("payload")
             .unwrap()
             .as_bytes()
             .to_vec();
-        // ReaderStream::new(bytes.as_slice())
-        bucket
-            .write_record(&entry_name)
-            .data(data)
-            .content_type("application/text")
-            .labels(Labels::from([("is_file".to_string(), "false".to_string())]))
-            .send()
-            .await?;
+
+        write_record_builder.data(data).send().await?;
     };
 
     output!(ctx, "Record written to '{}/{}'", bucket_name, entry_name);
+
+    Ok(())
+}
+
+async fn write_file_record(
+    _ctx: &CliContext,
+    bucket_name: &str,
+    entry_name: &str,
+    file_path: &str,
+    // args: &clap::ArgMatches,
+    write_record_builder: WriteRecordBuilder,
+) -> anyhow::Result<()> {
+    let file = tokio::fs::File::open(file_path).await?;
+    let content_length = file.metadata().await?.len();
+
+    if content_length == 0 {
+        return Err(anyhow::anyhow!("File is empty"));
+    }
+
+    let reader_stream = ReaderStream::new(file);
+
+    // Create a progress bar for file upload
+    let progress_bar = ProgressBar::new(content_length);
+    progress_bar.set_style(
+        ProgressStyle::with_template(
+            "[{elapsed_precise}] {bar:40.green/gray} {bytes}/{total_bytes} ({bytes_per_sec}) {msg}",
+        )?
+        .tick_strings(&["▁", "▃", "▄", "▅", "▆", "▇"]),
+    );
+    progress_bar.set_message(format!("Uploading to {}/{}", bucket_name, entry_name));
+
+    // Wrap the stream with progress tracking
+    let progress_stream = ProgressStream::new(reader_stream, progress_bar.clone());
+
+    write_record_builder
+        .stream(progress_stream)
+        .content_length(content_length)
+        .send()
+        .await?;
+
+    progress_bar.finish_with_message(format!(
+        "Uploaded {} to {}/{}",
+        ByteSize::b(content_length),
+        bucket_name,
+        entry_name
+    ));
 
     Ok(())
 }

--- a/src/cmd/write.rs
+++ b/src/cmd/write.rs
@@ -133,6 +133,8 @@ pub(crate) async fn write_handler(ctx: &CliContext, args: &clap::ArgMatches) -> 
     let client = build_client(ctx, &alias_or_url).await?;
     let bucket = client.get_bucket(&bucket_name).await?;
 
+    let quiet = args.get_flag("quiet");
+
     // Build record with common metadata (labels, timestamp)
     let mut builder = bucket.write_record(&entry_name);
     builder = apply_labels(builder, args)?;
@@ -151,6 +153,7 @@ pub(crate) async fn write_handler(ctx: &CliContext, args: &clap::ArgMatches) -> 
             &bucket_name,
             &entry_name,
             is_json,
+            quiet,
         )
         .await?
     } else {
@@ -158,7 +161,7 @@ pub(crate) async fn write_handler(ctx: &CliContext, args: &clap::ArgMatches) -> 
     };
 
     // Output success message unless quiet
-    if !args.get_flag("quiet") {
+    if !quiet {
         let elapsed_ms = start.elapsed().as_millis() as u64;
 
         if is_json {
@@ -233,6 +236,7 @@ async fn write_file(
     bucket_name: &str,
     entry_name: &str,
     is_json: bool,
+    quiet: bool,
 ) -> anyhow::Result<u64> {
     let file = tokio::fs::File::open(file_path).await?;
     let metadata = file.metadata().await?;
@@ -254,7 +258,7 @@ async fn write_file(
     let reader_stream = ReaderStream::new(file);
 
     if is_json {
-        // No progress bar in JSON mode
+        // No progress bar in JSON or quiet mode
         builder
             .content_type(content_type)
             .stream(reader_stream)
@@ -262,24 +266,26 @@ async fn write_file(
             .send()
             .await?;
     } else {
-        // Setup progress bar
-        let progress_bar = create_progress_bar(content_length, bucket_name, entry_name);
-        let progress_stream = ProgressStream::new(reader_stream, progress_bar.clone());
-
-        // Upload with progress tracking
-        builder
+        let builder = builder
             .content_type(content_type)
-            .stream(progress_stream)
-            .content_length(content_length)
-            .send()
-            .await?;
+            .content_length(content_length);
 
-        progress_bar.finish_with_message(format!(
-            "Uploaded {} to {}/{}",
-            ByteSize::b(content_length),
-            bucket_name,
-            entry_name
-        ));
+        if !quiet {
+            // Setup progress bar
+            let progress_bar = create_progress_bar(content_length, bucket_name, entry_name);
+            let progress_stream = ProgressStream::new(reader_stream, progress_bar.clone());
+            // Upload with progress tracking
+            builder.stream(progress_stream).send().await?;
+
+            progress_bar.finish_with_message(format!(
+                "Uploaded {} to {}/{}",
+                ByteSize::b(content_length),
+                bucket_name,
+                entry_name
+            ));
+        } else {
+            builder.stream(reader_stream).send().await?;
+        }
     }
 
     Ok(content_length)

--- a/src/cmd/write.rs
+++ b/src/cmd/write.rs
@@ -1,5 +1,11 @@
+use bytes::Bytes;
+use bytesize::ByteSize;
 use clap::{Arg, Command};
+use futures_util::stream::Stream;
+use indicatif::{ProgressBar, ProgressStyle};
 use reduct_rs::Labels;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 use tokio_util::io::ReaderStream;
 
 use crate::{
@@ -7,6 +13,39 @@ use crate::{
     io::{reduct::build_client, std::output},
     parse::{Resource, ResourcePathParser},
 };
+
+/// A wrapper stream that tracks upload progress
+struct ProgressStream<S> {
+    inner: S,
+    progress_bar: ProgressBar,
+}
+
+impl<S> ProgressStream<S> {
+    fn new(inner: S, progress_bar: ProgressBar) -> Self {
+        Self {
+            inner,
+            progress_bar,
+        }
+    }
+}
+
+impl<S, E> Stream for ProgressStream<S>
+where
+    S: Stream<Item = Result<Bytes, E>> + Unpin,
+{
+    type Item = Result<Bytes, E>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = &mut *self;
+        match Pin::new(&mut this.inner).poll_next(cx) {
+            Poll::Ready(Some(Ok(chunk))) => {
+                this.progress_bar.inc(chunk.len() as u64);
+                Poll::Ready(Some(Ok(chunk)))
+            }
+            other => other,
+        }
+    }
+}
 
 pub(crate) fn write_record_cmd() -> Command {
     Command::new("write")
@@ -51,16 +90,36 @@ pub(crate) async fn write_handler(ctx: &CliContext, args: &clap::ArgMatches) -> 
     if let Some(path) = args.get_one::<String>("path") {
         let reader_stream = ReaderStream::new(tokio::fs::File::open(path).await?);
         let content_length = tokio::fs::metadata(path).await?.len();
+
+        // Create a progress bar for file upload
+        let progress_bar = ProgressBar::new(content_length);
+        progress_bar.set_style(
+            ProgressStyle::with_template(
+                "[{elapsed_precise}] {bar:40.green/gray} {bytes}/{total_bytes} ({bytes_per_sec}) {msg}",
+            )?
+            .tick_strings(&["▁", "▃", "▄", "▅", "▆", "▇"]),
+        );
+        progress_bar.set_message(format!("Uploading to {}/{}", bucket_name, entry_name));
+
+        // Wrap the stream with progress tracking
+        let progress_stream = ProgressStream::new(reader_stream, progress_bar.clone());
+
         bucket
             .write_record(&entry_name)
             // .content_type("application/text")
             .labels(Labels::from([("name".to_string(), "malhar".to_string())]))
-            .stream(reader_stream)
+            .stream(progress_stream)
             .content_length(content_length)
             .send()
             .await?;
+
+        progress_bar.finish_with_message(format!(
+            "Uploaded {} to {}/{}",
+            ByteSize::b(content_length),
+            bucket_name,
+            entry_name
+        ));
     } else {
-        println!("found payload");
         let data = args
             .get_one::<String>("payload")
             .unwrap()

--- a/src/cmd/write.rs
+++ b/src/cmd/write.rs
@@ -247,51 +247,67 @@ mod tests {
         use super::*;
 
         /*
-            Verifies that content-type is set to application/octet-stream
-            when no extension is provided.
+            Test content-type handling for file uploads.
+            Tests: no extension (octet-stream), MIME guessing, and explicit content-type.
         */
         #[rstest]
+        #[case("testfile", b"Hello World", None, "application/octet-stream")]
+        #[case("test.json", b"{\"test\": \"data\"}", None, "application/json")]
+        #[case(
+            "test.txt",
+            b"hello world",
+            Some("application/json"),
+            "application/json"
+        )]
         #[tokio::test]
-        async fn test_write_file_with_no_extension(
+        async fn test_write_file_content_type(
             context: CliContext,
             #[future] bucket: Bucket,
+            #[case] filename: &str,
+            #[case] content: &[u8],
+            #[case] explicit_content_type: Option<&str>,
+            #[case] expected_content_type: &str,
         ) -> anyhow::Result<()> {
             let bucket = bucket.await;
-
-            // Create an empty file
             let temp_dir = tempfile::tempdir()?;
-            let file_path = temp_dir.path().join("testfile");
-            tokio::fs::write(&file_path, b"Hello World").await?;
+            let file_path = temp_dir.path().join(filename);
+            tokio::fs::write(&file_path, content).await?;
 
-            let args = write_record_cmd().get_matches_from(vec![
+            let entry_path = format!("local/{}/test-entry", bucket.name());
+            let mut args_vec = vec![
                 "write",
-                format!("local/{}/test-entry", bucket.name()).as_str(),
-                "-f",
+                entry_path.as_str(),
+                "--file",
                 file_path.to_str().unwrap(),
-            ]);
+            ];
 
+            // Add content-type if explicitly provided
+            if let Some(ct) = explicit_content_type {
+                args_vec.push("--content-type");
+                args_vec.push(ct);
+            }
+
+            let args = write_record_cmd().get_matches_from(args_vec);
             write_handler(&context, &args).await?;
 
             let record = bucket.read_record("test-entry").send().await?;
-            assert_eq!(record.content_type(), "application/octet-stream");
+            assert_eq!(record.content_type(), expected_content_type);
 
             Ok(())
         }
 
         /*
-            Verifies that an error is returned when writing an empty file.
+            Test that writing an empty file returns an error.
         */
         #[rstest]
         #[tokio::test]
-        async fn test_write_file_with_empty_file(
+        async fn test_write_empty_file(
             context: CliContext,
             #[future] bucket: Bucket,
         ) -> anyhow::Result<()> {
             let bucket = bucket.await;
-
-            // Create an empty file
             let temp_dir = tempfile::tempdir()?;
-            let file_path = temp_dir.path().join("test.txt");
+            let file_path = temp_dir.path().join("empty.txt");
             tokio::fs::write(&file_path, b"").await?;
 
             let args = write_record_cmd().get_matches_from(vec![
@@ -304,7 +320,6 @@ mod tests {
             let result = write_handler(&context, &args).await;
 
             assert!(result.is_err());
-
             let error_msg = result.unwrap_err().to_string();
             assert!(
                 error_msg.contains("File is empty"),
@@ -316,131 +331,37 @@ mod tests {
         }
 
         /*
-            Verifies that the content-type is guessed from the file extension
-            when --content-type is not supplied.
+            Test error conditions for invalid file paths.
+            Tests: file not found, directory instead of file.
         */
         #[rstest]
+        #[case("not_exist.json", "No such file or directory")]
+        #[case("/tmp/somedir", "No such file or directory")]
         #[tokio::test]
-        async fn test_write_file_with_mime_guess(
+        async fn test_write_file_path_errors(
             context: CliContext,
             #[future] bucket: Bucket,
+            #[case] file_path: &str,
+            #[case] expected_error: &str,
         ) -> anyhow::Result<()> {
             let bucket = bucket.await;
-            let temp_dir = tempfile::tempdir()?;
-            let file_path = temp_dir.path().join("test.json");
-            tokio::fs::write(&file_path, b"{\"test\": \"data\"}").await?;
 
-            // Write without explicit content-type, should guess from extension
+            let entry_path = format!("local/{}/test-entry", bucket.name());
             let args = write_record_cmd().get_matches_from(vec![
                 "write",
-                format!("local/{}/test-entry", bucket.name()).as_str(),
-                "--file",
-                file_path.to_str().unwrap(),
-            ]);
-
-            write_handler(&context, &args).await?;
-
-            let record = bucket.read_record("test-entry").send().await?;
-            assert_eq!(record.content_type(), "application/json");
-            assert_eq!(record.bytes().await?.as_ref(), b"{\"test\": \"data\"}");
-
-            Ok(())
-        }
-
-        /*
-            Verifies that the content-type is set to the value supplied
-            when --content-type is used.
-        */
-        #[rstest]
-        #[tokio::test]
-        async fn test_write_file_with_content_type(
-            context: CliContext,
-            #[future] bucket: Bucket,
-        ) -> anyhow::Result<()> {
-            let bucket = bucket.await;
-            let temp_dir = tempfile::tempdir()?;
-            let file_path = temp_dir.path().join("test.txt");
-            tokio::fs::write(&file_path, b"hello world").await?;
-
-            // Write without explicit content-type, should guess from extension
-            let args = write_record_cmd().get_matches_from(vec![
-                "write",
-                format!("local/{}/test-entry", bucket.name()).as_str(),
-                "--file",
-                file_path.to_str().unwrap(),
-                "--content-type",
-                "application/json",
-            ]);
-
-            write_handler(&context, &args).await?;
-
-            let record = bucket.read_record("test-entry").send().await?;
-            assert_eq!(record.content_type(), "application/json");
-
-            Ok(())
-        }
-
-        /*
-            Verifies that an error is returned when the file is not found.
-        */
-        #[rstest]
-        #[tokio::test]
-        async fn test_file_not_found(
-            context: CliContext,
-            #[future] bucket: Bucket,
-        ) -> anyhow::Result<()> {
-            let file_path = "not_exist.json";
-            let bucket = bucket.await;
-
-            let args = write_record_cmd().get_matches_from(vec![
-                "write",
-                format!("local/{}/test-entry", bucket.name()).as_str(),
+                entry_path.as_str(),
                 "-f",
                 file_path,
             ]);
 
             let result = write_handler(&context, &args).await;
 
-            // Should return an error for non-existent file
             assert!(result.is_err());
             let error_msg = result.unwrap_err().to_string();
             assert!(
-                error_msg.contains("No such file or directory"),
-                "Expected error about missing file, got: {}",
-                error_msg
-            );
-
-            Ok(())
-        }
-
-        /*
-            Verifies that an error is returned when a directory is passed
-            instead of a file.
-        */
-        #[rstest]
-        #[tokio::test]
-        async fn test_dir_path_for_file(
-            context: CliContext,
-            #[future] bucket: Bucket,
-        ) -> anyhow::Result<()> {
-            let file_path = "/tmp/somedir";
-            let bucket = bucket.await;
-
-            let args = write_record_cmd().get_matches_from(vec![
-                "write",
-                format!("local/{}/test-entry", bucket.name()).as_str(),
-                "-f",
-                file_path,
-            ]);
-
-            let result = write_handler(&context, &args).await;
-
-            // Should return an error for non-existent file
-            assert!(result.is_err());
-            let error_msg = result.unwrap_err().to_string();
-            assert!(
-                error_msg.contains("No such file or directory"),
-                "Expected error about missing file, got: {}",
+                error_msg.contains(expected_error),
+                "Expected error containing '{}', got: {}",
+                expected_error,
                 error_msg
             );
 

--- a/src/cmd/write.rs
+++ b/src/cmd/write.rs
@@ -6,7 +6,7 @@ use crate::{
     io::{reduct::build_client, std::output},
 };
 
-pub(crate) fn write_cmd() -> Command {
+pub(crate) fn write_record_cmd() -> Command {
     Command::new("write")
         .about("Write single record to a bucket")
         .arg(
@@ -20,8 +20,7 @@ pub(crate) fn write_cmd() -> Command {
                 .short('s')
                 .help("inline payload string.")
                 .required(true)
-                .value_name("PAYLOAD")
-                .conflicts_with("path"),
+                .value_name("PAYLOAD"),
         )
 }
 
@@ -40,7 +39,7 @@ pub(crate) async fn write_handler(ctx: &CliContext, args: &clap::ArgMatches) -> 
         .send()
         .await?;
 
-    output!(ctx, "Record written to '{}/{}' ", bucket_name, entry_name);
+    output!(ctx, "Record written to '{}/{}'", bucket_name, entry_name);
 
     Ok(())
 }
@@ -59,4 +58,74 @@ fn parse_entry_path(entry_path: &str) -> anyhow::Result<(String, String, String)
     let entry_name = caps.name("entry_name").unwrap().as_str().to_string();
 
     Ok((alias_or_url, bucket_name, entry_name))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::*;
+    use crate::context::tests::context;
+    use reduct_rs::Bucket;
+    use rstest::*;
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_write_string_record(
+        context: CliContext,
+        #[future] bucket: Bucket,
+        entry_path: String,
+        payload: String,
+    ) -> anyhow::Result<()> {
+        let bucket = bucket.await;
+
+        // Prepare args
+        let args = write_record_cmd().get_matches_from(vec![
+            "write",
+            format!("local/{}/{}", bucket.name(), entry_path).as_str(),
+            "--string",
+            payload.as_str(),
+        ]);
+
+        write_handler(&context, &args).await?;
+
+        let record = bucket.read_record(&entry_path).send().await?;
+
+        assert_eq!(record.bytes().await?, payload.as_bytes());
+        assert_eq!(
+            context.stdout().history(),
+            vec![format!(
+                "Record written to '{}/{}'",
+                bucket.name(),
+                entry_path
+            )]
+        );
+
+        Ok(())
+    }
+
+    #[fixture]
+    fn entry_path() -> String {
+        "test-entry".to_string()
+    }
+
+    #[fixture]
+    fn payload() -> String {
+        "test-payload".to_string()
+    }
+
+    #[fixture]
+    async fn bucket(context: CliContext) -> Bucket {
+        let bucket_name = unique_name("test-bucket");
+        let client = build_client(&context, "local").await.unwrap();
+        client.create_bucket(&bucket_name).send().await.unwrap()
+    }
+
+    fn unique_name(prefix: &str) -> String {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        format!("{}-{}", prefix, nanos)
+    }
 }

--- a/src/cmd/write.rs
+++ b/src/cmd/write.rs
@@ -74,6 +74,14 @@ pub(crate) fn write_record_cmd() -> Command {
                 .value_name("PATH")
                 .conflicts_with("payload"),
         )
+        .arg(
+            Arg::new("content-type")
+                .long("content-type")
+                .short('C')
+                .help("record content type.")
+                .required(false)
+                .value_name("MIME"),
+        )
 }
 
 pub(crate) async fn write_handler(ctx: &CliContext, args: &clap::ArgMatches) -> anyhow::Result<()> {
@@ -83,13 +91,18 @@ pub(crate) async fn write_handler(ctx: &CliContext, args: &clap::ArgMatches) -> 
     let entry_name = entry_name
         .ok_or_else(|| anyhow::anyhow!("ENTRY_PATH must be alias/bucket/path/to/entry"))?;
 
+    let content_type = args.get_one::<String>("content-type");
+
     let client = build_client(ctx, &alias_or_url).await?;
     let bucket = client.get_bucket(&bucket_name).await?;
-    let write_record_builder = bucket.write_record(&entry_name);
+    let mut write_record_builder = bucket.write_record(&entry_name);
+
+    if let Some(content_type) = content_type {
+        write_record_builder = write_record_builder.content_type(content_type);
+    }
+
     // .labels(labels)
-    // .content_type(content_type)
     // .timestamp_us(timestamp)
-    // .content_type("application/text")
 
     if let Some(path) = args.get_one::<String>("path") {
         write_file_record(ctx, &bucket_name, &entry_name, path, write_record_builder).await?;

--- a/src/cmd/write.rs
+++ b/src/cmd/write.rs
@@ -1,9 +1,9 @@
 use clap::{Arg, Command};
-use regex::Regex;
 
 use crate::{
     context::CliContext,
     io::{reduct::build_client, std::output},
+    parse::{Resource, ResourcePathParser},
 };
 
 pub(crate) fn write_record_cmd() -> Command {
@@ -12,6 +12,7 @@ pub(crate) fn write_record_cmd() -> Command {
         .arg(
             Arg::new("ENTRY_PATH")
                 .help("Full path the entry to write to")
+                .value_parser(ResourcePathParser::new().allow_alias())
                 .required(true),
         )
         .arg(
@@ -25,8 +26,12 @@ pub(crate) fn write_record_cmd() -> Command {
 }
 
 pub(crate) async fn write_handler(ctx: &CliContext, args: &clap::ArgMatches) -> anyhow::Result<()> {
-    let entry_path = args.get_one::<String>("ENTRY_PATH").unwrap().clone();
-    let (alias_or_url, bucket_name, entry_name) = parse_entry_path(&entry_path)?;
+    let entry_path = args.get_one::<Resource>("ENTRY_PATH").unwrap().clone();
+    let (alias_or_url, bucket_name, entry_name) = entry_path.triple()?;
+
+    let entry_name = entry_name
+        .ok_or_else(|| anyhow::anyhow!("ENTRY_PATH must be alias/bucket/path/to/entry"))?;
+
     let payload = args.get_one::<String>("payload").unwrap().clone();
 
     let client = build_client(ctx, &alias_or_url).await?;
@@ -42,22 +47,6 @@ pub(crate) async fn write_handler(ctx: &CliContext, args: &clap::ArgMatches) -> 
     output!(ctx, "Record written to '{}/{}'", bucket_name, entry_name);
 
     Ok(())
-}
-
-fn parse_entry_path(entry_path: &str) -> anyhow::Result<(String, String, String)> {
-    let re = Regex::new(r"^(?P<alias_or_url>[^/]+)/(?P<bucket_name>[^/]+)/(?P<entry_name>.+)$")?;
-    let caps = re.captures(entry_path).ok_or_else(|| {
-        anyhow::anyhow!(
-            "Invalid entry path. Expected ALIAS/BUCKET/ENTRY, got {}",
-            entry_path
-        )
-    })?;
-
-    let alias_or_url = caps.name("alias_or_url").unwrap().as_str().to_string();
-    let bucket_name = caps.name("bucket_name").unwrap().as_str().to_string();
-    let entry_name = caps.name("entry_name").unwrap().as_str().to_string();
-
-    Ok((alias_or_url, bucket_name, entry_name))
 }
 
 #[cfg(test)]

--- a/src/cmd/write.rs
+++ b/src/cmd/write.rs
@@ -9,6 +9,7 @@ use std::task::{Context, Poll};
 use std::time::SystemTime;
 use tokio_util::io::ReaderStream;
 
+use crate::parse::parse_time;
 use crate::{
     context::CliContext,
     io::{reduct::build_client, std::output},
@@ -83,6 +84,14 @@ pub(crate) fn write_record_cmd() -> Command {
                 .required(false)
                 .value_name("MIME"),
         )
+        .arg(
+            Arg::new("timestamp")
+                .long("timestamp")
+                .short('t')
+                .help("RFC 3339 / ISO timestamp or Unix timestamp in microseconds.")
+                .required(false)
+                .value_name("TIME"),
+        )
 }
 
 pub(crate) async fn write_handler(ctx: &CliContext, args: &clap::ArgMatches) -> anyhow::Result<()> {
@@ -96,10 +105,22 @@ pub(crate) async fn write_handler(ctx: &CliContext, args: &clap::ArgMatches) -> 
 
     let client = build_client(ctx, &alias_or_url).await?;
     let bucket = client.get_bucket(&bucket_name).await?;
-    let write_record_builder = bucket.write_record(&entry_name);
+    let mut write_record_builder = bucket.write_record(&entry_name);
 
     // .labels(labels)
-    // .timestamp_us(timestamp)
+
+    // Parse timestamp from argument or use current time
+    let timestamp_us = if let Some(timestamp_str) = args.get_one::<String>("timestamp") {
+        parse_time(Some(timestamp_str))
+            .map_err(|e| anyhow::anyhow!("Invalid timestamp: {}", e))?
+            .ok_or_else(|| anyhow::anyhow!("Timestamp parsing returned None"))?
+    } else {
+        SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)?
+            .as_micros() as u64
+    };
+
+    write_record_builder = write_record_builder.timestamp_us(timestamp_us);
 
     if let Some(path) = args.get_one::<String>("path") {
         // Check file path validity
@@ -129,7 +150,6 @@ pub(crate) async fn write_handler(ctx: &CliContext, args: &clap::ArgMatches) -> 
             .unwrap_or_else(|| "text/plain".to_string());
 
         let write_record_builder = write_record_builder.content_type(content_type);
-        let timestamp = SystemTime::now();
 
         let data = args
             .get_one::<String>("payload")
@@ -137,11 +157,7 @@ pub(crate) async fn write_handler(ctx: &CliContext, args: &clap::ArgMatches) -> 
             .as_bytes()
             .to_vec();
 
-        write_record_builder
-            .data(data)
-            .timestamp(timestamp)
-            .send()
-            .await?;
+        write_record_builder.data(data).send().await?;
     };
 
     output!(ctx, "Record written to '{}/{}'", bucket_name, entry_name);
@@ -178,11 +194,10 @@ async fn write_file_record(
 
     // Wrap the stream with progress tracking
     let progress_stream = ProgressStream::new(reader_stream, progress_bar.clone());
-    let timestamp = SystemTime::now();
+
     write_record_builder
         .stream(progress_stream)
         .content_length(content_length)
-        .timestamp(timestamp)
         .send()
         .await?;
 

--- a/src/cmd/write.rs
+++ b/src/cmd/write.rs
@@ -312,6 +312,45 @@ mod tests {
 
             Ok(())
         }
+
+        /*
+            Test that --quiet flag suppresses output.
+        */
+        #[rstest]
+        #[tokio::test]
+        async fn test_write_string_record_quiet(
+            context: CliContext,
+            #[future] bucket: Bucket,
+            entry_path: String,
+            payload: String,
+        ) -> anyhow::Result<()> {
+            let bucket = bucket.await;
+
+            let args = write_record_cmd().get_matches_from(vec![
+                "write",
+                format!("local/{}/{}", bucket.name(), entry_path).as_str(),
+                "--string",
+                payload.as_str(),
+                "--quiet",
+            ]);
+
+            write_handler(&context, &args).await?;
+
+            let record = bucket.read_record(&entry_path).send().await?;
+
+            // Verify record was written correctly
+            assert_eq!(record.bytes().await?, payload.as_bytes());
+
+            // Verify no output was produced
+            assert_eq!(
+                context.stdout().history(),
+                Vec::<String>::new(),
+                "Expected no output with --quiet flag, but got: {:?}",
+                context.stdout().history()
+            );
+
+            Ok(())
+        }
     }
 
     mod file_record_tests {

--- a/src/cmd/write.rs
+++ b/src/cmd/write.rs
@@ -6,6 +6,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 use reduct_rs::WriteRecordBuilder;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use std::time::SystemTime;
 use tokio_util::io::ReaderStream;
 
 use crate::{
@@ -95,25 +96,52 @@ pub(crate) async fn write_handler(ctx: &CliContext, args: &clap::ArgMatches) -> 
 
     let client = build_client(ctx, &alias_or_url).await?;
     let bucket = client.get_bucket(&bucket_name).await?;
-    let mut write_record_builder = bucket.write_record(&entry_name);
-
-    if let Some(content_type) = content_type {
-        write_record_builder = write_record_builder.content_type(content_type);
-    }
+    let write_record_builder = bucket.write_record(&entry_name);
 
     // .labels(labels)
     // .timestamp_us(timestamp)
 
     if let Some(path) = args.get_one::<String>("path") {
+        // Check file path validity
+        if !tokio::fs::metadata(path).await?.is_file() {
+            return Err(anyhow::anyhow!("Path '{}' is invalid or not a file", path));
+        }
+
+        // Guess content type from file extension if not provided
+        let content_type = if let Some(ct) = content_type {
+            ct.to_string()
+        } else {
+            let extension = std::path::Path::new(path)
+                .extension()
+                .and_then(|ext| ext.to_str())
+                .unwrap_or("");
+            mime_guess::from_ext(extension)
+                .first_or_octet_stream()
+                .to_string()
+        };
+
+        let write_record_builder = write_record_builder.content_type(content_type);
         write_file_record(ctx, &bucket_name, &entry_name, path, write_record_builder).await?;
     } else {
+        // If no path is provided, use the string payload
+        let content_type = content_type
+            .map(|ct| ct.to_string())
+            .unwrap_or_else(|| "text/plain".to_string());
+
+        let write_record_builder = write_record_builder.content_type(content_type);
+        let timestamp = SystemTime::now();
+
         let data = args
             .get_one::<String>("payload")
             .unwrap()
             .as_bytes()
             .to_vec();
 
-        write_record_builder.data(data).send().await?;
+        write_record_builder
+            .data(data)
+            .timestamp(timestamp)
+            .send()
+            .await?;
     };
 
     output!(ctx, "Record written to '{}/{}'", bucket_name, entry_name);
@@ -150,10 +178,11 @@ async fn write_file_record(
 
     // Wrap the stream with progress tracking
     let progress_stream = ProgressStream::new(reader_stream, progress_bar.clone());
-
+    let timestamp = SystemTime::now();
     write_record_builder
         .stream(progress_stream)
         .content_length(content_length)
+        .timestamp(timestamp)
         .send()
         .await?;
 
@@ -207,6 +236,34 @@ mod tests {
                 entry_path
             )]
         );
+
+        Ok(())
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_write_file_with_mime_guess(
+        context: CliContext,
+        #[future] bucket: Bucket,
+    ) -> anyhow::Result<()> {
+        let bucket = bucket.await;
+        let temp_dir = tempfile::tempdir()?;
+        let file_path = temp_dir.path().join("test.json");
+        tokio::fs::write(&file_path, b"{\"test\": \"data\"}").await?;
+
+        // Write without explicit content-type, should guess from extension
+        let args = write_record_cmd().get_matches_from(vec![
+            "write",
+            format!("local/{}/test-entry", bucket.name()).as_str(),
+            "--file",
+            file_path.to_str().unwrap(),
+        ]);
+
+        write_handler(&context, &args).await?;
+
+        let record = bucket.read_record("test-entry").send().await?;
+        assert_eq!(record.content_type(), "application/json");
+        assert_eq!(record.bytes().await?.as_ref(), b"{\"test\": \"data\"}");
 
         Ok(())
     }

--- a/src/cmd/write.rs
+++ b/src/cmd/write.rs
@@ -101,6 +101,14 @@ pub(crate) fn write_record_cmd() -> Command {
                 .action(clap::ArgAction::SetTrue),
         )
         .arg(
+            Arg::new("json")
+                .long("json")
+                .short('j')
+                .help("output result in JSON format with timing information.")
+                .required(false)
+                .action(clap::ArgAction::SetTrue),
+        )
+        .arg(
             Arg::new("labels")
                 .long("labels")
                 .short('l')
@@ -111,6 +119,10 @@ pub(crate) fn write_record_cmd() -> Command {
 }
 
 pub(crate) async fn write_handler(ctx: &CliContext, args: &clap::ArgMatches) -> anyhow::Result<()> {
+    use std::time::Instant;
+
+    let start = Instant::now();
+
     // Extract and validate entry path
     let entry_path = args.get_one::<Resource>("ENTRY_PATH").unwrap().clone();
     let (alias_or_url, bucket_name, entry_name) = entry_path.triple()?;
@@ -124,21 +136,41 @@ pub(crate) async fn write_handler(ctx: &CliContext, args: &clap::ArgMatches) -> 
     // Build record with common metadata (labels, timestamp)
     let mut builder = bucket.write_record(&entry_name);
     builder = apply_labels(builder, args)?;
-    builder = apply_timestamp(builder, args)?;
+    let (builder, timestamp_us) = apply_timestamp(builder, args)?;
 
     // Handle file or string payload
     let file_path = args.get_one::<String>("path");
     let content_type = args.get_one::<String>("content-type");
+    let is_json = args.get_flag("json");
 
-    if let Some(path) = file_path {
-        write_file(builder, content_type, path, &bucket_name, &entry_name).await?;
+    let bytes_written = if let Some(path) = file_path {
+        write_file(
+            builder,
+            content_type,
+            path,
+            &bucket_name,
+            &entry_name,
+            is_json,
+        )
+        .await?
     } else {
-        write_string(builder, content_type, args).await?;
-    }
+        write_string(builder, content_type, args).await?
+    };
 
     // Output success message unless quiet
     if !args.get_flag("quiet") {
-        output!(ctx, "Record written to '{}/{}'", bucket_name, entry_name);
+        let elapsed_ms = start.elapsed().as_millis() as u64;
+
+        if is_json {
+            let json = serde_json::json!({
+                "elapsed_ms": elapsed_ms,
+                "timestamp_us": timestamp_us,
+                "bytes_written": bytes_written
+            });
+            output!(ctx, "{}", json);
+        } else {
+            output!(ctx, "Record written to '{}/{}'", bucket_name, entry_name);
+        }
     }
 
     Ok(())
@@ -158,10 +190,11 @@ fn apply_labels(
 }
 
 /// Apply timestamp to the write record builder (from args or current time)
+/// Returns the builder and the timestamp value used
 fn apply_timestamp(
     builder: WriteRecordBuilder,
     args: &clap::ArgMatches,
-) -> anyhow::Result<WriteRecordBuilder> {
+) -> anyhow::Result<(WriteRecordBuilder, u64)> {
     let timestamp_us = if let Some(timestamp_str) = args.get_one::<String>("timestamp") {
         parse_time(Some(timestamp_str))
             .map_err(|e| anyhow::anyhow!("Invalid timestamp: {}", e))?
@@ -171,7 +204,7 @@ fn apply_timestamp(
             .duration_since(SystemTime::UNIX_EPOCH)?
             .as_micros() as u64
     };
-    Ok(builder.timestamp_us(timestamp_us))
+    Ok((builder.timestamp_us(timestamp_us), timestamp_us))
 }
 
 /// Determine content type from explicit arg or file extension
@@ -192,13 +225,15 @@ fn get_content_type(explicit: Option<&String>, file_path: &str) -> String {
 }
 
 /// Write a file record with progress tracking
+/// Returns the number of bytes written
 async fn write_file(
     builder: WriteRecordBuilder,
     content_type: Option<&String>,
     file_path: &str,
     bucket_name: &str,
     entry_name: &str,
-) -> anyhow::Result<()> {
+    is_json: bool,
+) -> anyhow::Result<u64> {
     let file = tokio::fs::File::open(file_path).await?;
     let metadata = file.metadata().await?;
 
@@ -218,34 +253,45 @@ async fn write_file(
     let content_type = get_content_type(content_type, file_path);
     let reader_stream = ReaderStream::new(file);
 
-    // Setup progress bar
-    let progress_bar = create_progress_bar(content_length, bucket_name, entry_name);
-    let progress_stream = ProgressStream::new(reader_stream, progress_bar.clone());
+    if is_json {
+        // No progress bar in JSON mode
+        builder
+            .content_type(content_type)
+            .stream(reader_stream)
+            .content_length(content_length)
+            .send()
+            .await?;
+    } else {
+        // Setup progress bar
+        let progress_bar = create_progress_bar(content_length, bucket_name, entry_name);
+        let progress_stream = ProgressStream::new(reader_stream, progress_bar.clone());
 
-    // Upload with progress tracking
-    builder
-        .content_type(content_type)
-        .stream(progress_stream)
-        .content_length(content_length)
-        .send()
-        .await?;
+        // Upload with progress tracking
+        builder
+            .content_type(content_type)
+            .stream(progress_stream)
+            .content_length(content_length)
+            .send()
+            .await?;
 
-    progress_bar.finish_with_message(format!(
-        "Uploaded {} to {}/{}",
-        ByteSize::b(content_length),
-        bucket_name,
-        entry_name
-    ));
+        progress_bar.finish_with_message(format!(
+            "Uploaded {} to {}/{}",
+            ByteSize::b(content_length),
+            bucket_name,
+            entry_name
+        ));
+    }
 
-    Ok(())
+    Ok(content_length)
 }
 
 /// Write a string record
+/// Returns the number of bytes written
 async fn write_string(
     builder: WriteRecordBuilder,
     content_type: Option<&String>,
     args: &clap::ArgMatches,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<u64> {
     let content_type = content_type.map(|s| s.as_str()).unwrap_or("text/plain");
 
     let data = args
@@ -254,9 +300,11 @@ async fn write_string(
         .as_bytes()
         .to_vec();
 
+    let bytes_written = data.len() as u64;
+
     builder.content_type(content_type).data(data).send().await?;
 
-    Ok(())
+    Ok(bytes_written)
 }
 
 /// Create a progress bar for file upload

--- a/src/cmd/write.rs
+++ b/src/cmd/write.rs
@@ -111,25 +111,57 @@ pub(crate) fn write_record_cmd() -> Command {
 }
 
 pub(crate) async fn write_handler(ctx: &CliContext, args: &clap::ArgMatches) -> anyhow::Result<()> {
+    // Extract and validate entry path
     let entry_path = args.get_one::<Resource>("ENTRY_PATH").unwrap().clone();
     let (alias_or_url, bucket_name, entry_name) = entry_path.triple()?;
-
     let entry_name = entry_name
         .ok_or_else(|| anyhow::anyhow!("ENTRY_PATH must be alias/bucket/path/to/entry"))?;
 
-    let content_type = args.get_one::<String>("content-type");
-
+    // Build client and get bucket
     let client = build_client(ctx, &alias_or_url).await?;
     let bucket = client.get_bucket(&bucket_name).await?;
-    let mut write_record_builder = bucket.write_record(&entry_name);
 
-    // Parse labels if provided
-    if let Some(labels_str) = args.get_one::<String>("labels") {
-        let labels = parse_labels(labels_str)?;
-        write_record_builder = write_record_builder.labels(labels);
+    // Build record with common metadata (labels, timestamp)
+    let mut builder = bucket.write_record(&entry_name);
+    builder = apply_labels(builder, args)?;
+    builder = apply_timestamp(builder, args)?;
+
+    // Handle file or string payload
+    let file_path = args.get_one::<String>("path");
+    let content_type = args.get_one::<String>("content-type");
+
+    if let Some(path) = file_path {
+        write_file(builder, content_type, path, &bucket_name, &entry_name).await?;
+    } else {
+        write_string(builder, content_type, args).await?;
     }
 
-    // Parse timestamp from argument or use current time
+    // Output success message unless quiet
+    if !args.get_flag("quiet") {
+        output!(ctx, "Record written to '{}/{}'", bucket_name, entry_name);
+    }
+
+    Ok(())
+}
+
+/// Apply labels to the write record builder if provided
+fn apply_labels(
+    builder: WriteRecordBuilder,
+    args: &clap::ArgMatches,
+) -> anyhow::Result<WriteRecordBuilder> {
+    if let Some(labels_str) = args.get_one::<String>("labels") {
+        let labels = parse_labels(labels_str)?;
+        Ok(builder.labels(labels))
+    } else {
+        Ok(builder)
+    }
+}
+
+/// Apply timestamp to the write record builder (from args or current time)
+fn apply_timestamp(
+    builder: WriteRecordBuilder,
+    args: &clap::ArgMatches,
+) -> anyhow::Result<WriteRecordBuilder> {
     let timestamp_us = if let Some(timestamp_str) = args.get_one::<String>("timestamp") {
         parse_time(Some(timestamp_str))
             .map_err(|e| anyhow::anyhow!("Invalid timestamp: {}", e))?
@@ -139,85 +171,60 @@ pub(crate) async fn write_handler(ctx: &CliContext, args: &clap::ArgMatches) -> 
             .duration_since(SystemTime::UNIX_EPOCH)?
             .as_micros() as u64
     };
-
-    write_record_builder = write_record_builder.timestamp_us(timestamp_us);
-
-    if let Some(path) = args.get_one::<String>("path") {
-        // Check file path validity
-        if !tokio::fs::metadata(path).await?.is_file() {
-            return Err(anyhow::anyhow!("Path '{}' is invalid or not a file", path));
-        }
-
-        // Guess content type from file extension if not provided
-        let content_type = if let Some(ct) = content_type {
-            ct.to_string()
-        } else {
-            let extension = std::path::Path::new(path)
-                .extension()
-                .and_then(|ext| ext.to_str())
-                .unwrap_or("");
-            mime_guess::from_ext(extension)
-                .first_or_octet_stream()
-                .to_string()
-        };
-
-        let write_record_builder = write_record_builder.content_type(content_type);
-        write_file_record(ctx, &bucket_name, &entry_name, path, write_record_builder).await?;
-    } else {
-        // If no path is provided, use the string payload
-        let content_type = content_type
-            .map(|ct| ct.to_string())
-            .unwrap_or_else(|| "text/plain".to_string());
-
-        let write_record_builder = write_record_builder.content_type(content_type);
-
-        let data = args
-            .get_one::<String>("payload")
-            .unwrap()
-            .as_bytes()
-            .to_vec();
-
-        write_record_builder.data(data).send().await?;
-    };
-
-    if !args.get_flag("quiet") {
-        output!(ctx, "Record written to '{}/{}'", bucket_name, entry_name);
-    }
-
-    Ok(())
+    Ok(builder.timestamp_us(timestamp_us))
 }
 
-async fn write_file_record(
-    _ctx: &CliContext,
+/// Determine content type from explicit arg or file extension
+fn get_content_type(explicit: Option<&String>, file_path: &str) -> String {
+    if let Some(ct) = explicit {
+        return ct.to_string();
+    }
+
+    std::path::Path::new(file_path)
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| {
+            mime_guess::from_ext(ext)
+                .first_or_octet_stream()
+                .to_string()
+        })
+        .unwrap_or_else(|| "application/octet-stream".to_string())
+}
+
+/// Write a file record with progress tracking
+async fn write_file(
+    builder: WriteRecordBuilder,
+    content_type: Option<&String>,
+    file_path: &str,
     bucket_name: &str,
     entry_name: &str,
-    file_path: &str,
-    // args: &clap::ArgMatches,
-    write_record_builder: WriteRecordBuilder,
 ) -> anyhow::Result<()> {
     let file = tokio::fs::File::open(file_path).await?;
-    let content_length = file.metadata().await?.len();
+    let metadata = file.metadata().await?;
 
+    // Validate file
+    if !metadata.is_file() {
+        return Err(anyhow::anyhow!(
+            "Path '{}' is invalid or not a file",
+            file_path
+        ));
+    }
+    let content_length = metadata.len();
     if content_length == 0 {
         return Err(anyhow::anyhow!("File is empty"));
     }
 
+    // Determine content type and create stream
+    let content_type = get_content_type(content_type, file_path);
     let reader_stream = ReaderStream::new(file);
 
-    // Create a progress bar for file upload
-    let progress_bar = ProgressBar::new(content_length);
-    progress_bar.set_style(
-        ProgressStyle::with_template(
-            "[{elapsed_precise}] {bar:40.green/gray} {bytes}/{total_bytes} ({bytes_per_sec}) {msg}",
-        )?
-        .tick_strings(&["▁", "▃", "▄", "▅", "▆", "▇"]),
-    );
-    progress_bar.set_message(format!("Uploading to {}/{}", bucket_name, entry_name));
-
-    // Wrap the stream with progress tracking
+    // Setup progress bar
+    let progress_bar = create_progress_bar(content_length, bucket_name, entry_name);
     let progress_stream = ProgressStream::new(reader_stream, progress_bar.clone());
 
-    write_record_builder
+    // Upload with progress tracking
+    builder
+        .content_type(content_type)
         .stream(progress_stream)
         .content_length(content_length)
         .send()
@@ -231,6 +238,39 @@ async fn write_file_record(
     ));
 
     Ok(())
+}
+
+/// Write a string record
+async fn write_string(
+    builder: WriteRecordBuilder,
+    content_type: Option<&String>,
+    args: &clap::ArgMatches,
+) -> anyhow::Result<()> {
+    let content_type = content_type.map(|s| s.as_str()).unwrap_or("text/plain");
+
+    let data = args
+        .get_one::<String>("payload")
+        .unwrap()
+        .as_bytes()
+        .to_vec();
+
+    builder.content_type(content_type).data(data).send().await?;
+
+    Ok(())
+}
+
+/// Create a progress bar for file upload
+fn create_progress_bar(content_length: u64, bucket_name: &str, entry_name: &str) -> ProgressBar {
+    let progress_bar = ProgressBar::new(content_length);
+    progress_bar.set_style(
+        ProgressStyle::with_template(
+            "[{elapsed_precise}] {bar:40.green/gray} {bytes}/{total_bytes} ({bytes_per_sec}) {msg}",
+        )
+        .expect("Invalid progress bar template")
+        .tick_strings(&["▁", "▃", "▄", "▅", "▆", "▇"]),
+    );
+    progress_bar.set_message(format!("Uploading to {}/{}", bucket_name, entry_name));
+    progress_bar
 }
 
 #[cfg(test)]

--- a/src/cmd/write.rs
+++ b/src/cmd/write.rs
@@ -1,4 +1,5 @@
 use clap::{Arg, Command};
+use reduct_rs::Labels;
 
 use crate::{
     context::CliContext,
@@ -21,7 +22,17 @@ pub(crate) fn write_record_cmd() -> Command {
                 .short('s')
                 .help("inline payload string.")
                 .required(true)
-                .value_name("PAYLOAD"),
+                .value_name("PAYLOAD")
+                .conflicts_with("path"),
+        )
+        .arg(
+            Arg::new("path")
+                .long("file")
+                .short('f')
+                .help("payload file path.")
+                .required(false)
+                .value_name("PATH")
+                .conflicts_with("payload"),
         )
 }
 
@@ -32,15 +43,25 @@ pub(crate) async fn write_handler(ctx: &CliContext, args: &clap::ArgMatches) -> 
     let entry_name = entry_name
         .ok_or_else(|| anyhow::anyhow!("ENTRY_PATH must be alias/bucket/path/to/entry"))?;
 
-    let payload = args.get_one::<String>("payload").unwrap().clone();
+    let mut is_file = false;
+    let data = if let Some(path) = args.get_one::<String>("path") {
+        is_file = true;
+        std::fs::read(path)?
+    } else {
+        args.get_one::<String>("payload")
+            .unwrap()
+            .as_bytes()
+            .to_vec()
+    };
 
     let client = build_client(ctx, &alias_or_url).await?;
 
     let bucket = client.get_bucket(&bucket_name).await?;
     bucket
         .write_record(&entry_name)
-        .data(payload)
+        .data(data)
         .content_type("application/text")
+        .labels(Labels::from([("is_file".to_string(), is_file.to_string())]))
         .send()
         .await?;
 

--- a/src/cmd/write.rs
+++ b/src/cmd/write.rs
@@ -3,7 +3,8 @@ use bytesize::ByteSize;
 use clap::{Arg, Command};
 use futures_util::stream::Stream;
 use indicatif::{ProgressBar, ProgressStyle};
-use reduct_rs::WriteRecordBuilder;
+use reduct_rs::{Labels, WriteRecordBuilder};
+use std::collections::HashMap;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::SystemTime;
@@ -15,6 +16,46 @@ use crate::{
     io::{reduct::build_client, std::output},
     parse::{Resource, ResourcePathParser},
 };
+
+/// Parse labels from either key=value,key=value format or JSON object format
+fn parse_labels(labels_str: &str) -> anyhow::Result<Labels> {
+    let trimmed = labels_str.trim();
+
+    // Try to parse as JSON first
+    if trimmed.starts_with('{') {
+        let labels_map: HashMap<String, String> = serde_json::from_str(trimmed)
+            .map_err(|e| anyhow::anyhow!("Failed to parse labels as JSON: {}", e))?;
+        return Ok(labels_map);
+    }
+
+    // Parse as key=value,key=value format
+    let mut labels = HashMap::new();
+    for pair in trimmed.split(',') {
+        let pair = pair.trim();
+        if pair.is_empty() {
+            continue;
+        }
+
+        let parts: Vec<&str> = pair.splitn(2, '=').collect();
+        if parts.len() != 2 {
+            return Err(anyhow::anyhow!(
+                "Invalid label format '{}': expected key=value",
+                pair
+            ));
+        }
+
+        let key = parts[0].trim();
+        let value = parts[1].trim();
+
+        if key.is_empty() {
+            return Err(anyhow::anyhow!("Label key cannot be empty in '{}'", pair));
+        }
+
+        labels.insert(key.to_string(), value.to_string());
+    }
+
+    Ok(labels)
+}
 
 /// A wrapper stream that tracks upload progress
 struct ProgressStream<S> {
@@ -91,13 +132,22 @@ pub(crate) fn write_record_cmd() -> Command {
                 .help("RFC 3339 / ISO timestamp or Unix timestamp in microseconds.")
                 .required(false)
                 .value_name("TIME"),
-        ).arg(
+        )
+        .arg(
             Arg::new("quiet")
                 .long("quiet")
                 .short('q')
                 .help("suppress successful output.")
                 .required(false)
                 .action(clap::ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("labels")
+                .long("labels")
+                .short('l')
+                .help("labels as key=value,key=value or a JSON object.")
+                .required(false)
+                .value_name("LABELS"),
         )
 }
 
@@ -114,7 +164,11 @@ pub(crate) async fn write_handler(ctx: &CliContext, args: &clap::ArgMatches) -> 
     let bucket = client.get_bucket(&bucket_name).await?;
     let mut write_record_builder = bucket.write_record(&entry_name);
 
-    // .labels(labels)
+    // Parse labels if provided
+    if let Some(labels_str) = args.get_one::<String>("labels") {
+        let labels = parse_labels(labels_str)?;
+        write_record_builder = write_record_builder.labels(labels);
+    }
 
     // Parse timestamp from argument or use current time
     let timestamp_us = if let Some(timestamp_str) = args.get_one::<String>("timestamp") {
@@ -315,5 +369,74 @@ mod tests {
             .unwrap()
             .as_nanos();
         format!("{}-{}", prefix, nanos)
+    }
+
+    #[test]
+    fn test_parse_labels_key_value_format() {
+        let labels = parse_labels("key1=value1,key2=value2").unwrap();
+        assert_eq!(labels.len(), 2);
+        assert_eq!(labels.get("key1"), Some(&"value1".to_string()));
+        assert_eq!(labels.get("key2"), Some(&"value2".to_string()));
+    }
+
+    #[test]
+    fn test_parse_labels_key_value_with_spaces() {
+        let labels = parse_labels(" key1 = value1 , key2 = value2 ").unwrap();
+        assert_eq!(labels.len(), 2);
+        assert_eq!(labels.get("key1"), Some(&"value1".to_string()));
+        assert_eq!(labels.get("key2"), Some(&"value2".to_string()));
+    }
+
+    #[test]
+    fn test_parse_labels_json_format() {
+        let labels = parse_labels(r#"{"key1":"value1","key2":"value2"}"#).unwrap();
+        assert_eq!(labels.len(), 2);
+        assert_eq!(labels.get("key1"), Some(&"value1".to_string()));
+        assert_eq!(labels.get("key2"), Some(&"value2".to_string()));
+    }
+
+    #[test]
+    fn test_parse_labels_empty_value() {
+        let labels = parse_labels("key1=,key2=value2").unwrap();
+        assert_eq!(labels.len(), 2);
+        assert_eq!(labels.get("key1"), Some(&"".to_string()));
+        assert_eq!(labels.get("key2"), Some(&"value2".to_string()));
+    }
+
+    #[test]
+    fn test_parse_labels_value_with_equals() {
+        let labels = parse_labels("key1=value=with=equals").unwrap();
+        assert_eq!(labels.len(), 1);
+        assert_eq!(labels.get("key1"), Some(&"value=with=equals".to_string()));
+    }
+
+    #[test]
+    fn test_parse_labels_invalid_format() {
+        let result = parse_labels("invalid");
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("expected key=value"));
+    }
+
+    #[test]
+    fn test_parse_labels_empty_key() {
+        let result = parse_labels("=value");
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("key cannot be empty"));
+    }
+
+    #[test]
+    fn test_parse_labels_invalid_json() {
+        let result = parse_labels(r#"{"key1":"value1""#);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Failed to parse labels as JSON"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ mod parse;
 
 use crate::cmd::alias::{alias_cmd, alias_handler};
 use crate::cmd::attachment::{attachment_cmd, attachment_handler};
-use crate::cmd::write::write_cmd;
+use crate::cmd::write::{write_cmd, write_handler};
 use crate::context::ContextBuilder;
 use std::time::Duration;
 
@@ -107,6 +107,7 @@ async fn main() -> anyhow::Result<()> {
 
         Some(("cp", args)) => cp_handler(&ctx, args).await,
         Some(("rm", args)) => rm_handler(&ctx, args).await,
+        Some(("write", args)) => write_handler(&ctx, args).await,
         _ => Ok(()),
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ mod parse;
 
 use crate::cmd::alias::{alias_cmd, alias_handler};
 use crate::cmd::attachment::{attachment_cmd, attachment_handler};
-use crate::cmd::write::{write_cmd, write_handler};
+use crate::cmd::write::{write_handler, write_record_cmd};
 use crate::context::ContextBuilder;
 use std::time::Duration;
 
@@ -78,7 +78,7 @@ fn cli() -> Command {
         .subcommand(lifecycle_cmd())
         .subcommand(cp_cmd())
         .subcommand(rm_cmd())
-        .subcommand(write_cmd())
+        .subcommand(write_record_cmd())
 }
 
 #[tokio::main]

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod parse;
 
 use crate::cmd::alias::{alias_cmd, alias_handler};
 use crate::cmd::attachment::{attachment_cmd, attachment_handler};
+use crate::cmd::write::write_cmd;
 use crate::context::ContextBuilder;
 use std::time::Duration;
 
@@ -77,6 +78,7 @@ fn cli() -> Command {
         .subcommand(lifecycle_cmd())
         .subcommand(cp_cmd())
         .subcommand(rm_cmd())
+        .subcommand(write_cmd())
 }
 
 #[tokio::main]

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -10,6 +10,8 @@ mod resource_path;
 pub(crate) mod widely_used_args;
 
 pub(crate) use byte_size::ByteSizeParser;
-pub(crate) use helpers::{fetch_and_filter_entries, parse_query_params, parse_time, QueryParams};
+pub(crate) use helpers::{
+    fetch_and_filter_entries, parse_labels, parse_query_params, parse_time, QueryParams,
+};
 pub(crate) use quota_type::QuotaTypeParser;
 pub(crate) use resource_path::{Resource, ResourcePathParser};

--- a/src/parse/helpers.rs
+++ b/src/parse/helpers.rs
@@ -701,6 +701,7 @@ mod test {
     }
 
     mod parse_labels {
+        use crate::parse::parse_labels;
 
         #[test]
         fn test_parse_labels_key_value_format() {

--- a/src/parse/helpers.rs
+++ b/src/parse/helpers.rs
@@ -8,8 +8,9 @@ use crate::context::CliContext;
 use chrono::{DateTime, Local, LocalResult, NaiveDate, NaiveDateTime, TimeZone, Utc};
 use clap::parser::MatchesError;
 use clap::ArgMatches;
-use reduct_rs::{Bucket, EntryInfo};
+use reduct_rs::{Bucket, EntryInfo, Labels};
 use serde_json::Value;
+use std::collections::HashMap;
 use std::time::Duration;
 
 pub(crate) async fn fetch_and_filter_entries(
@@ -179,6 +180,46 @@ fn timestamp_micros_to_u64(micros: i64, time_str: &str) -> anyhow::Result<u64> {
             time_str
         )
     })
+}
+
+/// Parse labels from either key=value,key=value format or JSON object format
+pub(crate) fn parse_labels(labels_str: &str) -> anyhow::Result<Labels> {
+    let trimmed = labels_str.trim();
+
+    // Try to parse as JSON first
+    if trimmed.starts_with('{') {
+        let labels_map: HashMap<String, String> = serde_json::from_str(trimmed)
+            .map_err(|e| anyhow::anyhow!("Failed to parse labels as JSON: {}", e))?;
+        return Ok(labels_map);
+    }
+
+    // Parse as key=value,key=value format
+    let mut labels = HashMap::new();
+    for pair in trimmed.split(',') {
+        let pair = pair.trim();
+        if pair.is_empty() {
+            continue;
+        }
+
+        let parts: Vec<&str> = pair.splitn(2, '=').collect();
+        if parts.len() != 2 {
+            return Err(anyhow::anyhow!(
+                "Invalid label format '{}': expected key=value",
+                pair
+            ));
+        }
+
+        let key = parts[0].trim();
+        let value = parts[1].trim();
+
+        if key.is_empty() {
+            return Err(anyhow::anyhow!("Label key cannot be empty in '{}'", pair));
+        }
+
+        labels.insert(key.to_string(), value.to_string());
+    }
+
+    Ok(labels)
 }
 
 #[derive(Clone, Debug)]
@@ -656,6 +697,78 @@ mod test {
 
             assert_eq!(query_params.parallel, 3);
             assert_eq!(query_params.ttl, Duration::from_secs(36));
+        }
+    }
+
+    mod parse_labels {
+
+        #[test]
+        fn test_parse_labels_key_value_format() {
+            let labels = parse_labels("key1=value1,key2=value2").unwrap();
+            assert_eq!(labels.len(), 2);
+            assert_eq!(labels.get("key1"), Some(&"value1".to_string()));
+            assert_eq!(labels.get("key2"), Some(&"value2".to_string()));
+        }
+
+        #[test]
+        fn test_parse_labels_key_value_with_spaces() {
+            let labels = parse_labels(" key1 = value1 , key2 = value2 ").unwrap();
+            assert_eq!(labels.len(), 2);
+            assert_eq!(labels.get("key1"), Some(&"value1".to_string()));
+            assert_eq!(labels.get("key2"), Some(&"value2".to_string()));
+        }
+
+        #[test]
+        fn test_parse_labels_json_format() {
+            let labels = parse_labels(r#"{"key1":"value1","key2":"value2"}"#).unwrap();
+            assert_eq!(labels.len(), 2);
+            assert_eq!(labels.get("key1"), Some(&"value1".to_string()));
+            assert_eq!(labels.get("key2"), Some(&"value2".to_string()));
+        }
+
+        #[test]
+        fn test_parse_labels_empty_value() {
+            let labels = parse_labels("key1=,key2=value2").unwrap();
+            assert_eq!(labels.len(), 2);
+            assert_eq!(labels.get("key1"), Some(&"".to_string()));
+            assert_eq!(labels.get("key2"), Some(&"value2".to_string()));
+        }
+
+        #[test]
+        fn test_parse_labels_value_with_equals() {
+            let labels = parse_labels("key1=value=with=equals").unwrap();
+            assert_eq!(labels.len(), 1);
+            assert_eq!(labels.get("key1"), Some(&"value=with=equals".to_string()));
+        }
+
+        #[test]
+        fn test_parse_labels_invalid_format() {
+            let result = parse_labels("invalid");
+            assert!(result.is_err());
+            assert!(result
+                .unwrap_err()
+                .to_string()
+                .contains("expected key=value"));
+        }
+
+        #[test]
+        fn test_parse_labels_empty_key() {
+            let result = parse_labels("=value");
+            assert!(result.is_err());
+            assert!(result
+                .unwrap_err()
+                .to_string()
+                .contains("key cannot be empty"));
+        }
+
+        #[test]
+        fn test_parse_labels_invalid_json() {
+            let result = parse_labels(r#"{"key1":"value1""#);
+            assert!(result.is_err());
+            assert!(result
+                .unwrap_err()
+                .to_string()
+                .contains("Failed to parse labels as JSON"));
         }
     }
 }


### PR DESCRIPTION
Addresses https://github.com/reductstore/reduct-cli/issues/259

This PR adds a following command.
`reduct-cli write <ENTRY_PATH> [-s <PAYLOAD> | -f <PATH>] [OPTIONS]`.

The command is used to write a single record with either string or a file. It takes optional content-type, timestamp and labels too, to be added to the record being added. It supports `--quiet` flag to supress the output when successful and `--json` to show output in JSON format when successful.

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?
feature

### What was changed?
Command `write` is added to create a single record in a bucket.

### Related issues
https://github.com/reductstore/reduct-cli/issues/259

### Does this PR introduce a breaking change?
No

### Other information:
