### PR TITLE
ci: use incremental cargo cache

### DIFF
--- a/.github/actions/aws-cargo-cache/action.yml
+++ b/.github/actions/aws-cargo-cache/action.yml
@@ -1,5 +1,5 @@
 name: 'AWS Credentials and Cargo Cache'
-description: 'Configures AWS credentials via OIDC and sets up Cargo cache.'
+description: 'Configures Cargo target caching, S3-backed sccache, and a small Cargo download cache.'
 inputs:
   target:
     description: 'Target triple.'
@@ -28,16 +28,64 @@ runs:
           echo "Using preset RUST_MINOR=${RUST_MINOR}"
         fi
 
-    - name: Use cache for Cargo
+    - name: Install sccache
+      uses: mozilla-actions/sccache-action@v0.0.9
+
+    - name: Configure sccache
+      shell: bash
+      run: |
+        export RUSTC_WRAPPER=sccache
+        export SCCACHE_BUCKET=reduct-cache
+        export SCCACHE_ENDPOINT=https://fsn1.your-objectstorage.com
+        export SCCACHE_REGION=fsn1
+        export SCCACHE_S3_KEY_PREFIX="sccache/${{ github.repository }}/${{ inputs.target }}/${{ inputs.profile }}/rust${RUST_MINOR}"
+        export SCCACHE_IDLE_TIMEOUT=0
+        export AWS_ACCESS_KEY_ID="${{ inputs.access-key-id }}"
+        export AWS_SECRET_ACCESS_KEY="${{ inputs.secret-access-key }}"
+        export AWS_REGION=fsn1
+        export AWS_DEFAULT_REGION=fsn1
+
+        {
+          echo "RUSTC_WRAPPER=${RUSTC_WRAPPER}"
+          echo "SCCACHE_BUCKET=${SCCACHE_BUCKET}"
+          echo "SCCACHE_ENDPOINT=${SCCACHE_ENDPOINT}"
+          echo "SCCACHE_REGION=${SCCACHE_REGION}"
+          echo "SCCACHE_S3_KEY_PREFIX=${SCCACHE_S3_KEY_PREFIX}"
+          echo "SCCACHE_IDLE_TIMEOUT=${SCCACHE_IDLE_TIMEOUT}"
+          echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}"
+          echo "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}"
+          echo "AWS_REGION=${AWS_REGION}"
+          echo "AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}"
+        } >> "$GITHUB_ENV"
+
+        sccache --start-server
+
+    - name: Use cache for Cargo downloads
       uses: runs-on/cache@v4
       with:
         path: |
-          ~/.cargo/bin/
           ~/.cargo/registry/index/
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
-          target/
-        key: ${{ runner.os }}-${{ inputs.target }}-${{ inputs.profile }}-cargo-rust${{ env.RUST_MINOR }}-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
+        key: ${{ runner.os }}-${{ inputs.target }}-${{ inputs.profile }}-cargo-downloads-rust${{ env.RUST_MINOR }}-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ inputs.target }}-${{ inputs.profile }}-cargo-downloads-rust${{ env.RUST_MINOR }}-
+      env:
+        RUNS_ON_S3_BUCKET_CACHE: reduct-cache
+        RUNS_ON_S3_BUCKET_ENDPOINT: https://fsn1.your-objectstorage.com
+        AWS_ACCESS_KEY_ID: ${{ inputs.access-key-id }}
+        AWS_SECRET_ACCESS_KEY: ${{ inputs.secret-access-key }}
+        AWS_REGION: fsn1
+        AWS_DEFAULT_REGION: fsn1
+
+    - name: Use cache for Cargo target
+      uses: runs-on/cache@v4
+      with:
+        path: target/
+        key: ${{ runner.os }}-${{ inputs.target }}-${{ inputs.profile }}-cargo-target-rust${{ env.RUST_MINOR }}-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-${{ inputs.target }}-${{ inputs.profile }}-cargo-target-rust${{ env.RUST_MINOR }}-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}-
+          ${{ runner.os }}-${{ inputs.target }}-${{ inputs.profile }}-cargo-target-rust${{ env.RUST_MINOR }}-
       env:
         RUNS_ON_S3_BUCKET_CACHE: reduct-cache
         RUNS_ON_S3_BUCKET_ENDPOINT: https://fsn1.your-objectstorage.com

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,9 @@ jobs:
           RUSTFLAGS: "-C target-feature=+crt-static"
         run: cargo build --release --locked --target ${{ matrix.target }}
 
+      - name: Show sccache stats
+        run: sccache --show-stats
+
       - name: Upload binary
         uses: actions/upload-artifact@v6
         with:
@@ -153,6 +156,9 @@ jobs:
         run: docker run --network=host -v ${PWD}/misc:/misc --env RS_API_TOKEN=TOKEN -d ${{env.REGISTRY_IMAGE}}:main
       - name: Run Client CLI tests
         run: RS_API_TOKEN=TOKEN cargo test --locked -- --test-threads=1
+
+      - name: Show sccache stats
+        run: sccache --show-stats
 
 
   check_tag:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1430,7 +1430,7 @@ dependencies = [
 [[package]]
 name = "reduct-base"
 version = "1.21.0"
-source = "git+https://github.com/reductstore/reductstore.git?branch=main#4f7c9587a34a76ea2e14e417da71757c4e16f7c5"
+source = "git+https://github.com/reductstore/reductstore.git?branch=main#0622b3d1889a38d0ba99317d81c6afe5761a7f25"
 dependencies = [
  "bytes",
  "chrono",
@@ -1477,7 +1477,7 @@ dependencies = [
 [[package]]
 name = "reduct-rs"
 version = "1.20.0"
-source = "git+https://github.com/reductstore/reduct-rs?branch=main#1d0c3bd54a42558689144dc2dc5c2e840a164bb1"
+source = "git+https://github.com/reductstore/reduct-rs?branch=main#8fdbc1bd655e7d3e08345be1928fa23a0fc3a802"
 dependencies = [
  "async-channel",
  "async-stream",


### PR DESCRIPTION
## Summary
- upgrade the Cargo cache composite action to use S3-backed sccache
- split Cargo downloads from target/ caching
- key target caches by OS, target, profile, Rust minor, dependency set, and commit SHA with restore prefixes
- show sccache stats after binary builds and CLI tests

## Validation
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/ci.yml
- python3 YAML parse for workflow and composite action
- git diff --check