### PR TITLE
Add lifecycle processing interval support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 target
 .idea
+.kilo/
+!.kilo/
+.kilo/*
+!.kilo/skills/
+!.kilo/skills/**

--- a/.kilo/skills/create-pr/SKILL.md
+++ b/.kilo/skills/create-pr/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: create-pr
+description: Create GitHub pull requests with the gh CLI using the reductstore/.github PR template, then update CHANGELOG.md with the created PR ID and commit the changelog (do not push). Use when a user asks to open a PR and record its ID in the changelog.
+---
+
+# Create Pr
+
+## Overview
+
+Create a PR using the standardized template from reductstore/.github, then record the PR number in CHANGELOG.md and commit the changelog without pushing.
+
+## Workflow
+
+### 1) Preconditions
+- Ensure `gh auth status` is logged in and the current branch is the intended PR branch.
+- Ensure the working tree is clean (or only the intended changes are present).
+- Use context from the current conversation to infer intent, scope, and any constraints.
+
+### 2) Understand changes and rationale
+- Compare the current branch against `main` to understand what changed and why (use this to derive the PR title, description, and rationale):
+  - `git fetch origin main`
+  - `git log --oneline origin/main..HEAD`
+  - `git diff --stat origin/main...HEAD`
+  - `git diff origin/main...HEAD`
+- If the branch name starts with an issue number (e.g., `123-...`), use that issue in the rationale and fill the `Closes #` line in the PR template.
+- If the branch name does not include an issue number, infer the likely issue from changes and conversation context, or leave `Closes #` empty if unsure.
+
+### 3) Fetch the PR template
+Use the helper script to download the latest PR template from reductstore/.github:
+
+```bash
+./.codex/skills/create-pr/scripts/fetch_pr_template.sh /tmp/pr_template.md
+```
+
+Fill in the template file with the relevant summary, testing, and rationale derived from the diff and conversation context.
+
+### 4) Create the PR with gh
+Use the filled template as the PR body:
+
+```bash
+gh pr create --title "<title>" --body-file /tmp/pr_template.md
+```
+
+Capture the PR number after creation:
+
+```bash
+gh pr view --json number -q .number
+```
+
+### 5) Update CHANGELOG.md
+- Find the appropriate section (usually the most recent/unreleased section).
+- Add a new entry following the existing style in the file.
+- Include the PR ID as `#<number>` exactly as prior entries do.
+
+### 6) Commit (no push)
+Stage and commit the changelog update only:
+
+```bash
+git add CHANGELOG.md
+git commit -m "Update changelog for PR #<number>"
+```
+
+Do not push.
+
+## Resources
+
+### scripts/
+- `fetch_pr_template.sh`: Download the latest PR template from reductstore/.github.

--- a/.kilo/skills/create-pr/scripts/fetch_pr_template.sh
+++ b/.kilo/skills/create-pr/scripts/fetch_pr_template.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <output-file>" >&2
+  exit 1
+fi
+
+output_file="$1"
+
+curl -sS -L \
+  "https://raw.githubusercontent.com/reductstore/.github/main/.github/pull_request_template.md" \
+  -o "$output_file"
+
+if [[ ! -s "$output_file" ]]; then
+  echo "Template download failed or empty: $output_file" >&2
+  exit 1
+fi
+
+echo "Template saved to $output_file"

--- a/.kilo/skills/fix-tests/SKILL.md
+++ b/.kilo/skills/fix-tests/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: fix-tests
+description: Fix Rust test failures and compilation errors. Use when tests do not compile, warnings break CI, or unit/integration tests fail (especially when a ReductStore container must be running). Includes guidance to run tests, start ReductStore via Docker, improve assertions, and reduce test duplication.
+---
+
+# Fix Tests
+
+## Overview
+
+Fix compilation errors, warnings, and failing tests in Rust repos, including integration tests that require a running ReductStore instance.
+
+## Workflow
+
+### 1. Establish baseline
+
+- Run `cargo test` first to capture compile errors, warnings, and failing tests.
+- If tests are integration-heavy or flaky, re-run with `-- --test-threads=1` to reduce concurrency.
+
+### 2. Fix compilation errors and warnings
+
+- Address compiler errors first; they block everything else.
+- Remove unused imports, fix type mismatches, and update signatures.
+- Re-run `cargo test` or a focused test module to confirm the compile fix.
+
+### 3. Start ReductStore when tests need it
+
+If failures show connection errors to `localhost:8383` or ReductStore endpoints:
+
+- Use CI as the source of truth for how to run the service.
+- Start a local container (examples mirror CI):
+  - `docker run --network=host -v ${PWD}/misc:/misc --env RS_API_TOKEN=TOKEN -d reduct/store:latest`
+  - `docker run --network=host -v ${PWD}/misc:/misc --env RS_API_TOKEN=TOKEN -d reduct/store:main`
+- Run tests with the token set:
+  - `RS_API_TOKEN=TOKEN cargo test -- --test-threads=1`
+
+### 4. Fix failing tests
+
+- Update test logic to match current behavior or expected outputs.
+- Prefer small, deterministic fixtures. Avoid network or timing dependencies where possible.
+- Re-run the smallest relevant test(s) before full suite.
+
+### 5. Improve test readability
+
+- Reduce duplication by extracting helper functions/fixtures inside `#[cfg(test)]` modules.
+- Add assertion messages that explain intent and expected values.
+- Keep tests short and focused on a single behavior.
+
+### 6. Verify and report
+
+- Re-run full test suite (or CI-equivalent subset) and confirm passes.
+- Always validate against both `reduct/store:latest` and `reduct/store:main` after changes:
+  - `docker run --network=host -v ${PWD}/misc:/misc --env RS_API_TOKEN=TOKEN -d reduct/store:latest`
+  - `RS_API_TOKEN=TOKEN cargo test -- --test-threads=1`
+  - Stop/remove the container, then repeat for `reduct/store:main`.
+- Summarize changes and note any remaining gaps (e.g., requires running container).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve time parsing for --start and --stop options, [PR-226](https://github.com/reductstore/reduct-cli/pull/226) by @yaslam-dev
 - Added `write` command to write a single record to a bucket, [PR-275](https://github.com/reductstore/reduct-cli/pull/275) by @vbmade2000
 - Add `--json` flag to `bucket ls`, `bucket show`, `bucket create`, `bucket update`, `bucket rename` and `bucket rm` command, [PR-274](https://github.com/reductstore/reduct-cli/pull/274) by @vbmade2000
-- Add lifecycle processing interval support to create, update, and show commands.
+- Add lifecycle processing interval support to create, update, and show commands, [PR-276](https://github.com/reductstore/reduct-cli/pull/276) by @atimin
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve time parsing for --start and --stop options, [PR-226](https://github.com/reductstore/reduct-cli/pull/226) by @yaslam-dev
 - Added `write` command to write a single record to a bucket, [PR-275](https://github.com/reductstore/reduct-cli/pull/275) by @vbmade2000
 - Add `--json` flag to `bucket ls`, `bucket show`, `bucket create`, `bucket update`, `bucket rename` and `bucket rm` command, [PR-274](https://github.com/reductstore/reduct-cli/pull/274) by @vbmade2000
+- Add lifecycle processing interval support to create, update, and show commands.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1430,7 +1430,7 @@ dependencies = [
 [[package]]
 name = "reduct-base"
 version = "1.21.0"
-source = "git+https://github.com/reductstore/reductstore.git?branch=main#0622b3d1889a38d0ba99317d81c6afe5761a7f25"
+source = "git+https://github.com/reductstore/reductstore.git?branch=main#edf52d282a3d2da77a29d05348c9fd72f3595ed5"
 dependencies = [
  "bytes",
  "chrono",
@@ -1480,7 +1480,7 @@ dependencies = [
 [[package]]
 name = "reduct-rs"
 version = "1.20.0"
-source = "git+https://github.com/reductstore/reduct-rs?branch=main#8fdbc1bd655e7d3e08345be1928fa23a0fc3a802"
+source = "git+https://github.com/reductstore/reduct-rs?branch=main#1539ec015e7d71d02c2b66f095ffe97ec953ef4b"
 dependencies = [
  "async-channel",
  "async-stream",

--- a/src/cmd/bucket/ls.rs
+++ b/src/cmd/bucket/ls.rs
@@ -98,16 +98,15 @@ fn record_range_values(oldest: u64, latest: u64, is_empty: bool) -> (String, Str
 }
 
 fn print_full_list(ctx: &CliContext, bucket_list: BucketInfoList) {
-    let is_json = ctx.json();
-
-    if bucket_list.buckets.is_empty() {
-        if is_json {
-            output!(ctx, "{}", "[]");
-        }
+    if ctx.json() {
+        output!(ctx, "{}", serde_json::to_string(&bucket_list).unwrap());
         return;
     }
 
-    let bucket_list2 = bucket_list.clone();
+    if bucket_list.buckets.is_empty() {
+        return;
+    }
+
     let rows = bucket_list
         .buckets
         .into_iter()
@@ -133,10 +132,6 @@ fn print_full_list(ctx: &CliContext, bucket_list: BucketInfoList) {
         })
         .collect::<Vec<_>>();
 
-    if is_json {
-        output!(ctx, "{}", serde_json::to_string(&bucket_list2).unwrap());
-        return;
-    }
     let table = Table::new(rows).with(Style::markdown()).to_string();
     output!(ctx, "{}", table);
 }

--- a/src/cmd/lifecycle/create.rs
+++ b/src/cmd/lifecycle/create.rs
@@ -55,6 +55,13 @@ pub(super) fn create_lifecycle_cmd() -> Command {
                 .help("Interval between lifecycle runs (e.g. 10m, 1h)")
                 .required(false),
         )
+        .arg(
+            Arg::new("processing-interval")
+                .long("processing-interval")
+                .value_name("DURATION")
+                .help("Interval for processing lifecycle records (e.g. 6h, 12h, 1d)")
+                .required(false),
+        )
         .arg(make_entries_arg())
         .arg(make_when_arg())
 }
@@ -72,6 +79,7 @@ pub(super) async fn create_lifecycle(
     let lifecycle_type = *args.get_one::<LifecycleType>("type").unwrap();
     let older_than = args.get_one::<String>("older-than").unwrap();
     let interval = args.get_one::<String>("interval");
+    let processing_interval = args.get_one::<String>("processing-interval");
     let entries = args
         .get_many::<String>("entries")
         .unwrap_or_default()
@@ -88,6 +96,9 @@ pub(super) async fn create_lifecycle(
     settings.entries = entries;
     if let Some(interval) = interval {
         settings.interval = interval.to_string();
+    }
+    if let Some(processing_interval) = processing_interval {
+        settings.processing_interval = Some(processing_interval.to_string());
     }
     if let Some(when) = when {
         settings.when = Some(serde_json::from_str(when)?);
@@ -126,6 +137,8 @@ mod tests {
             "1h",
             "--interval",
             "10m",
+            "--processing-interval",
+            "6h",
             "--entries",
             "entry1",
             "entry2",
@@ -139,6 +152,10 @@ mod tests {
         assert_eq!(lifecycle.settings.bucket, bucket);
         assert_eq!(lifecycle.settings.older_than, "1h");
         assert_eq!(lifecycle.settings.interval, "10m");
+        assert_eq!(
+            lifecycle.settings.processing_interval.as_deref(),
+            Some("6h")
+        );
         assert_eq!(lifecycle.settings.entries, vec!["entry1", "entry2"]);
         assert_eq!(
             lifecycle.settings.when.unwrap(),
@@ -166,6 +183,7 @@ mod tests {
 
         let lifecycle = client.get_lifecycle(&test_lifecycle).await.unwrap();
         assert_eq!(lifecycle.settings.interval, "3600s");
+        assert_eq!(lifecycle.settings.processing_interval, None);
     }
 
     #[rstest]

--- a/src/cmd/lifecycle/show.rs
+++ b/src/cmd/lifecycle/show.rs
@@ -58,6 +58,14 @@ pub(super) async fn show_lifecycle_handler(
         labeled_cell("Bucket", lifecycle.settings.bucket.clone()),
         labeled_cell("Older Than", lifecycle.settings.older_than.clone()),
         labeled_cell("Interval", lifecycle.settings.interval.clone()),
+        labeled_cell(
+            "Processing Interval",
+            lifecycle
+                .settings
+                .processing_interval
+                .clone()
+                .unwrap_or_else(|| "None".to_string()),
+        ),
         labeled_cell("Entries", format!("{:?}", lifecycle.settings.entries)),
     ];
 
@@ -107,7 +115,30 @@ mod tests {
         assert!(output[0].contains("Type: Delete"));
         assert!(output[0].contains("Older Than: 1h"));
         assert!(output[0].contains("Interval: 10m"));
+        assert!(output[0].contains("Processing Interval: None"));
         assert!(output[0].contains("When: None"));
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_show_lifecycle_with_processing_interval(context: CliContext) {
+        let lifecycle = unique_name("test-lifecycle");
+        let bucket = unique_name("test-bucket");
+        let client = prepare_lifecycle(&context, &lifecycle, &bucket)
+            .await
+            .unwrap();
+
+        let mut settings = client.get_lifecycle(&lifecycle).await.unwrap().settings;
+        settings.processing_interval = Some("1d".to_string());
+        client.update_lifecycle(&lifecycle, settings).await.unwrap();
+
+        let args = show_lifecycle_cmd()
+            .get_matches_from(vec!["show", format!("local/{}", lifecycle).as_str()]);
+        show_lifecycle_handler(&context, &args).await.unwrap();
+
+        let output = context.stdout().history();
+        assert_eq!(output.len(), 1);
+        assert!(output[0].contains("Processing Interval: 1d"));
     }
 
     #[rstest]

--- a/src/cmd/lifecycle/update.rs
+++ b/src/cmd/lifecycle/update.rs
@@ -56,6 +56,13 @@ pub(super) fn update_lifecycle_cmd() -> Command {
                 .help("Interval between lifecycle runs (e.g. 10m, 1h)")
                 .required(false),
         )
+        .arg(
+            Arg::new("processing-interval")
+                .long("processing-interval")
+                .value_name("DURATION")
+                .help("Interval for processing lifecycle records (e.g. 6h, 12h, 1d)")
+                .required(false),
+        )
         .arg(make_entries_arg())
         .arg(make_when_arg())
 }
@@ -84,6 +91,9 @@ pub(super) async fn update_lifecycle_handler(
     }
     if let Some(interval) = args.get_one::<String>("interval") {
         settings.interval = interval.to_string();
+    }
+    if let Some(processing_interval) = args.get_one::<String>("processing-interval") {
+        settings.processing_interval = Some(processing_interval.to_string());
     }
     if let Some(entries) = args.get_many::<String>("entries") {
         settings.entries = entries.map(|s| s.to_string()).collect();
@@ -126,6 +136,8 @@ mod tests {
             "2h",
             "--interval",
             "30m",
+            "--processing-interval",
+            "12h",
             "--entries",
             "entry1",
             "entry2",
@@ -139,10 +151,52 @@ mod tests {
         assert_eq!(lifecycle.settings.bucket, bucket2);
         assert_eq!(lifecycle.settings.older_than, "2h");
         assert_eq!(lifecycle.settings.interval, "30m");
+        assert_eq!(
+            lifecycle.settings.processing_interval.as_deref(),
+            Some("12h")
+        );
         assert_eq!(lifecycle.settings.entries, vec!["entry1", "entry2"]);
         assert_eq!(
             lifecycle.settings.when.unwrap(),
             json!({"&label": {"$eq": 1}})
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_update_lifecycle_preserves_processing_interval(
+        context: crate::context::CliContext,
+    ) {
+        let test_lifecycle = unique_name("test-lifecycle");
+        let bucket = unique_name("test-bucket");
+        let client = prepare_lifecycle(&context, &test_lifecycle, &bucket)
+            .await
+            .unwrap();
+
+        let mut settings = client
+            .get_lifecycle(&test_lifecycle)
+            .await
+            .unwrap()
+            .settings;
+        settings.processing_interval = Some("6h".to_string());
+        client
+            .update_lifecycle(&test_lifecycle, settings)
+            .await
+            .unwrap();
+
+        let args = update_lifecycle_cmd().get_matches_from(vec![
+            "update",
+            format!("local/{}", test_lifecycle).as_str(),
+            "--older-than",
+            "2h",
+        ]);
+        update_lifecycle_handler(&context, &args).await.unwrap();
+
+        let lifecycle = client.get_lifecycle(&test_lifecycle).await.unwrap();
+        assert_eq!(lifecycle.settings.older_than, "2h");
+        assert_eq!(
+            lifecycle.settings.processing_interval.as_deref(),
+            Some("6h")
         );
     }
 


### PR DESCRIPTION
Closes #275

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

Add the `--processing-interval` option to lifecycle create and update commands.
Persist the setting through the ReductStore client and display it in lifecycle show output.
Add coverage for creating, updating, preserving, and displaying the processing interval.

### Related issues

Closes #275.

### Does this PR introduce a breaking change?

No.

### Other information:

The update includes the Kilo skill definitions used for the repository workflow.
