### PR TITLE
Add --json output for server commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add lifecycle processing interval support to create, update, and show commands, [PR-276](https://github.com/reductstore/reduct-cli/pull/276) by @atimin
 - Add `--json` flag to `rm` command, [PR-277](https://github.com/reductstore/reduct-cli/pull/277) by @vbmade2000
 - Add `--json` flag to `token` command, [PR-283](https://github.com/reductstore/reduct-cli/pull/283) by @vbmade2000
+- Add `--json` flag to `server` command, [PR-284](https://github.com/reductstore/reduct-cli/pull/284) by @vbmade2000
 
 ### Changed
 

--- a/src/cmd/server/license.rs
+++ b/src/cmd/server/license.rs
@@ -22,22 +22,34 @@ pub(super) async fn get_server_license(
     args: &ArgMatches,
 ) -> anyhow::Result<()> {
     let alias = args.get_one::<String>("ALIAS_OR_URL").unwrap();
+    let is_json = ctx.json();
 
     let client = crate::io::reduct::build_client(ctx, alias).await?;
 
     if let Some(license) = client.server_info().await?.license {
-        output!(ctx, "Licensee:\t{}", license.licensee);
-        output!(ctx, "Invoice:\t{}", license.invoice);
-        output!(ctx, "Expiry Date:\t{}", license.expiry_date);
-        output!(ctx, "Plan:\t\t{}", license.plan);
-        output!(ctx, "Num. Devices:\t{}", license.device_number);
-        output!(ctx, "Disk Quota:\t{} TB", license.disk_quota);
-        output!(ctx, "Fingerprint:\t{}", license.fingerprint);
+        if is_json {
+            output!(ctx, "{}", serde_json::to_string(&license).unwrap());
+        } else {
+            output!(ctx, "Licensee:\t{}", license.licensee);
+            output!(ctx, "Invoice:\t{}", license.invoice);
+            output!(ctx, "Expiry Date:\t{}", license.expiry_date);
+            output!(ctx, "Plan:\t\t{}", license.plan);
+            output!(ctx, "Num. Devices:\t{}", license.device_number);
+            output!(ctx, "Disk Quota:\t{} TB", license.disk_quota);
+            output!(ctx, "Fingerprint:\t{}", license.fingerprint);
+        }
     } else {
-        output!(
+        if is_json {
+            let license_json = serde_json::json!({
+                "license": "BUSL-1.1 (Limited commercial use. See https://www.reduct.store/pricing for details)"
+            });
+            output!(ctx, "{}", serde_json::to_string(&license_json).unwrap());
+        } else {
+            output!(
             ctx,
             "BUSL-1.1 (Limited commercial use. See https://www.reduct.store/pricing for details)"
         );
+        }
     }
 
     Ok(())
@@ -46,7 +58,10 @@ pub(super) async fn get_server_license(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::context::tests::context;
+    use crate::context::{
+        tests::{context, MockOutput},
+        ContextBuilder,
+    };
     use rstest::rstest;
 
     #[rstest]
@@ -56,5 +71,27 @@ mod tests {
         get_server_license(&context, &matches).await.unwrap();
 
         assert_eq!(context.stdout().history(), ["BUSL-1.1 (Limited commercial use. See https://www.reduct.store/pricing for details)"]);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_get_server_license_json(context: crate::context::CliContext) {
+        let matches = server_license_cmd().get_matches_from(vec!["license", "local"]);
+
+        let ctx = ContextBuilder::new()
+            .config_path(context.config_path())
+            .json(Some(true))
+            .output(Box::new(MockOutput::new()))
+            .build();
+
+        get_server_license(&ctx, &matches).await.unwrap();
+
+        let license_json: serde_json::Value =
+            serde_json::from_str(&ctx.stdout().history()[0]).unwrap();
+
+        assert_eq!(
+            license_json["license"],
+            "BUSL-1.1 (Limited commercial use. See https://www.reduct.store/pricing for details)"
+        );
     }
 }

--- a/src/cmd/server/status.rs
+++ b/src/cmd/server/status.rs
@@ -28,6 +28,11 @@ pub(super) async fn get_server_status(
     let client = build_client(ctx, alias).await?;
     let info = client.server_info().await?;
 
+    if ctx.json() {
+        output!(ctx, "{}", serde_json::to_string(&info).unwrap());
+        return Ok(());
+    }
+
     output!(ctx, "Status: \tOk ✅");
     output!(ctx, "Version:\t{}", info.version);
     output!(
@@ -52,7 +57,10 @@ pub(super) async fn get_server_status(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::context::tests::context;
+    use crate::context::{
+        tests::{context, MockOutput},
+        ContextBuilder,
+    };
     use rstest::rstest;
 
     #[rstest]
@@ -68,5 +76,45 @@ mod tests {
             context.stdout().history()[3],
             "License:\tBUSL-1.1 (Limited commercial use)"
         );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_get_server_status_json(context: crate::context::CliContext) {
+        let args = server_status_cmd().get_matches_from(vec!["status", "local"]);
+
+        let ctx = ContextBuilder::new()
+            .config_path(context.config_path())
+            .json(Some(true))
+            .output(Box::new(MockOutput::new()))
+            .build();
+
+        get_server_status(&ctx, &args).await.unwrap();
+
+        let status_json: serde_json::Value =
+            serde_json::from_str(&ctx.stdout().history()[0]).unwrap();
+
+        // Verify top level keys
+        let main_object = status_json.as_object().unwrap();
+        assert!(main_object.contains_key("version"));
+        assert!(main_object.contains_key("instance_name"));
+        assert!(main_object.contains_key("instance_role"));
+        assert!(main_object.contains_key("bucket_count"));
+        assert!(main_object.contains_key("usage"));
+        assert!(main_object.contains_key("uptime"));
+        assert!(main_object.contains_key("oldest_record"));
+        assert!(main_object.contains_key("latest_record"));
+        assert!(main_object.contains_key("license"));
+
+        // Verify keys under default keys
+        let default_object = main_object["defaults"].as_object().unwrap();
+        assert!(default_object.contains_key("bucket"));
+
+        // Verify bucket key
+        let bucket_object = default_object["bucket"].as_object().unwrap();
+        assert!(bucket_object.contains_key("quota_type"));
+        assert!(bucket_object.contains_key("quota_size"));
+        assert!(bucket_object.contains_key("max_block_size"));
+        assert!(bucket_object.contains_key("max_block_records"));
     }
 }

--- a/src/cmd/server/status.rs
+++ b/src/cmd/server/status.rs
@@ -106,11 +106,11 @@ mod tests {
         assert!(main_object.contains_key("latest_record"));
         assert!(main_object.contains_key("license"));
 
-        // Verify keys under default keys
+        // Verify "defaults" keys
         let default_object = main_object["defaults"].as_object().unwrap();
         assert!(default_object.contains_key("bucket"));
 
-        // Verify bucket key
+        // Verify "bucket" key
         let bucket_object = default_object["bucket"].as_object().unwrap();
         assert!(bucket_object.contains_key("quota_type"));
         assert!(bucket_object.contains_key("quota_size"));


### PR DESCRIPTION
Closes https://github.com/reductstore/reduct-cli/issues/253

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?
feature
(Bug fix, feature, docs update, ...)

### What was changed?
`reduct-cli server` can output in JSON format when -j option is used.
(Describe the changes)

### Related issues

(Add links to related issues)

### Does this PR introduce a breaking change?
No

(What changes might users need to make in their application due to this PR?)

### Other information:
